### PR TITLE
ETB How-to rewording

### DIFF
--- a/FAQ/HOWTO_electronic_throttle_body.md
+++ b/FAQ/HOWTO_electronic_throttle_body.md
@@ -4,9 +4,9 @@
 
 ## _WARNING: An electronic throttle, if misconfigured or damaged, has the ability to open the throttle without your foot on the pedal, potentially leading to engine damage [or a crash](https://en.wikipedia.org/wiki/2009%E2%80%9311_Toyota_vehicle_recalls).  Proceed with caution!_
 
-rusEfi supports controlling an electronic throttle body.  Also called "drive by wire", this means there's no physical cable between your foot and the throttle.  Your foot presses on a pedal without a cable, just a sensor.  The ECU interprets this information, and converts it to a desired position for the throttle, and then works to drive the throttle plate to the desired position.
+rusEFI supports electronic throttle body control.  Also called drive by wire (DBW), there is no physical cable between the throttle pedal, or pedal position sensor (PPS), and the throttle. The PPS is only a sensor that measures how far depressed it is. The ECU interprets the information from the PPS, and converts it to a desired position for the throttle. The ECU then drives the throttle plate to the desired position and compares the throttle plate position using the throttle position sensor (TPS) to the desired position set by the PPS and makes adjustments as requried.
 
-This offers a number of benefits:
+There are several benefits by allowing the ECU to control the position of the throttle. 
 
 - Rev limiter by simply closing the throttle (not yet implemented)
 - Superior idle control
@@ -17,13 +17,13 @@ This offers a number of benefits:
 
 Electronic throttles typically consist of:
 - A brushed DC motor.  Positive torque pushes the throttle open, and negative torque pushes the throttle closed.
-- A position sensor.  This tells the ECU the true position of the throttle, so that the ECU can use the motor to hold it where we want it.  This is a potentiometer or hall effect angle sensor, depending on the throttle, though they both function the same.
-- A "limp home" return spring.  This spring pushes the throttle plate back towards a position that's nearly closed, approximatly the correct amount of air for idle (generally 3-10% open).
+- A TPS.  This is an angle sensor, commonly a potentiometer or hall sensor, which tells the ECU the actual position of the throttle. This is used as feedback to the ECU to accurately set and hold the throttle position.  
+- A "limp home" return spring.  This spring holds the throttle position open slightly, commonly 3%-10%, appoximately enough to idle. This allows the vehicle to "limp home" in the event the ECU can no longer operate the throttle.
 
-rusEfi hardware and software have components to deal with all three of these parts of the throttle.
-- DC motor driver H-bridge(s) to control the motor.  An H-bridge can apply a variable voltage (via PWM) in either direction to the motor.
-- Analog inputs and corresponding software to detect the position of the throttle and accelerator pedal.
-- A control algorithm that uses a table to linearize the return spring, and PID to move the throttle to the targeted position.
+rusEFI hardware and software has been designed to work with all three of these parts of the throttle.
+- DC motor driver H-bridge(s) to control the motor.  An H-bridge can apply a variable voltage using PWM in either direction. Both directions is important to be able to open and close the throttle completely. 
+- Analog inputs and corresponding software to measure both the TPS and PPS.
+- A control algorithm that uses a table to linearize the effects of the return spring and PID to move the throttle to the targeted position.
 
 ## Configuration & Tuning
 


### PR DESCRIPTION
I reworded the ETB documentation page to remove first and second person language. Also changed wording to read, in my opinion, easier.