### PR TITLE
Sync to rusefi wiki

### DIFF
--- a/.github/workflows/sync-wiki.yaml
+++ b/.github/workflows/sync-wiki.yaml
@@ -1,8 +1,9 @@
 name: Sync Wiki
 
-on: push
-  branches:
-  - master
+on:
+  push:
+    branches:
+    - master
 
 jobs:
   sync:

--- a/.github/workflows/sync-wiki.yaml
+++ b/.github/workflows/sync-wiki.yaml
@@ -1,0 +1,32 @@
+name: Sync Wiki
+
+on: push
+  branches:
+  - master
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Check out docs repo
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+        repository: chuckwagoncomputing/rusefi.wiki
+        persist-credentials: false
+
+    - name: Merge
+      run: |
+        git remote add technical-git https://github.com/rusefi/rusefi_documentation.git
+        git fetch technical-git
+        git config --local user.email "action@github.com"
+        git config --local user.name "GitHub Action"
+        git merge technical-git/master
+
+    - name: Push changes
+      uses: ad-m/github-push-action@master
+      with:
+        repository: chuckwagoncomputing/rusefi.wiki
+        github_token: ${{ secrets.ACCESS_TOKEN }}
+        branch: master

--- a/.github/workflows/sync-wiki.yaml
+++ b/.github/workflows/sync-wiki.yaml
@@ -14,7 +14,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
-        repository: chuckwagoncomputing/rusefi.wiki
+        repository: rusefi/rusefi.wiki
         persist-credentials: false
 
     - name: Merge
@@ -28,6 +28,6 @@ jobs:
     - name: Push changes
       uses: ad-m/github-push-action@master
       with:
-        repository: chuckwagoncomputing/rusefi.wiki
+        repository: rusefi/rusefi.wiki
         github_token: ${{ secrets.ACCESS_TOKEN }}
         branch: master


### PR DESCRIPTION
This needs the same setup as https://github.com/rusefi/rusefi/pull/1698.
Please merge that and allow it to run (will need to edit the wiki to trigger it) before merging this.
This action runs on any push to master.