### PR TITLE
remove home link from mkdocs sidebar

### DIFF
--- a/mkdocs/mkdocs.yaml
+++ b/mkdocs/mkdocs.yaml
@@ -12,7 +12,6 @@ plugins:
 markdown_extensions:
   - sane_lists
 nav:
-  - 'Home': Home
   - 'Downloads': Download
   - 'Getting Started':
     - 'How to search the Wiki': HOWTO/HOWTO-Search-on-rusEFI-wiki


### PR DESCRIPTION
This will fix #262. We don't need a home link in the sidebar in the first place, as there is already one at the top. The reason that this link causes an issue is that it points at /Home, while the configured canonical URL for the home page is at /, so the links generated in the home page assume that the current URL is /. If the URL is in fact /Home, all the links in the home page no longer work.