### PR TITLE
add sitemap to sidebar

### DIFF
--- a/mkdocs/mkdocs.yaml
+++ b/mkdocs/mkdocs.yaml
@@ -83,3 +83,4 @@ nav:
   - 'Misc':
     - 'How to convert from carburetor to EFI': how-to-convert-from-carburetor-to-EFI
     - 'Do I need a wideband oxygen sensor?': do-i-need-wideband-oxygen-sensor
+  - 'Sitemap': sitemap.xml


### PR DESCRIPTION
This should allow crawlers to find all the pages that have no links to them. Google already knows about the sitemap, but site checker tools do not.