### PR TITLE
Use exclude plugin to allow symlinking instead of copying

### DIFF
--- a/.github/workflows/sync-wiki3.yaml
+++ b/.github/workflows/sync-wiki3.yaml
@@ -25,16 +25,11 @@ jobs:
       run: |
         sudo apt update
         sudo apt install sshpass
-        pip install mkdocs mkdocs-ezlinks-plugin mkdocs-exclude
+        bash ./bin/mkdocs-install.sh
 
     - name: Generate static pages using mkdocs
       run: |
-        shopt -s extglob
-        cd mkdocs
-        mkdir docs
-        cp -r ../!(mkdocs) docs
-        cp style.css docs
-        mkdocs build
+        bash ./bin/mkdocs-run.sh
 
     - name: Set SSH variables
       env:

--- a/.github/workflows/sync-wiki3.yaml
+++ b/.github/workflows/sync-wiki3.yaml
@@ -25,7 +25,7 @@ jobs:
       run: |
         sudo apt update
         sudo apt install sshpass
-        pip install mkdocs mkdocs-ezlinks-plugin
+        pip install mkdocs mkdocs-ezlinks-plugin mkdocs-exclude
 
     - name: Generate static pages using mkdocs
       run: |

--- a/HOWTO-Test-Doc-Changes.md
+++ b/HOWTO-Test-Doc-Changes.md
@@ -32,10 +32,9 @@ You need to set up an access token in your repository secrets for Actions.
 
 The easiest way to test Wiki3 is locally. You could also set up a webserver and your repository secrets to let the workflow upload it for you, but here I'll just explain how to test locally.
 
-The full instructions for installing MkDocs can be found [here](https://www.mkdocs.org/user-guide/installation/), but the short version is to run `pip install mkdocs`.  
-You will also need some plugin, which you can install with `pip install mkdocs-ezlinks-plugin mkdocs-exclude`.
+The full instructions for installing MkDocs can be found [here](https://www.mkdocs.org/user-guide/installation/), but there is also a script included in the repo that will install it for you.  
+Run `bash ./bin/mkdocs-install.sh` if you have a Debian/apt-based system. If not, read the script to find which python packages you need to install.
 
 Once MkDocs is installed, you can now generate the site.  
-I do this with a one-liner, run from the root directory of the repo:  
-`cd mkdocs; ln -s .. docs; cp style.css ..; mkdocs build; cd ..; rm style.css`  
-MkDocs expects the Markdown documentation files to be in a "docs" subdirectory, so we create it and move everything to it, and then we can go ahead and build the site.
+There is a script included to do this as well.  
+Run `bash ./bin/mkdocs-run.sh`, and the site files will then be found at ./mkdocs/site  

--- a/HOWTO-Test-Doc-Changes.md
+++ b/HOWTO-Test-Doc-Changes.md
@@ -33,9 +33,9 @@ You need to set up an access token in your repository secrets for Actions.
 The easiest way to test Wiki3 is locally. You could also set up a webserver and your repository secrets to let the workflow upload it for you, but here I'll just explain how to test locally.
 
 The full instructions for installing MkDocs can be found [here](https://www.mkdocs.org/user-guide/installation/), but the short version is to run `pip install mkdocs`.  
-You will also need the EzLinks plugin, which you can install with `pip install mkdocs-ezlinks-plugin`.
+You will also need some plugin, which you can install with `pip install mkdocs-ezlinks-plugin mkdocs-exclude`.
 
 Once MkDocs is installed, you can now generate the site.  
 I do this with a one-liner, run from the root directory of the repo:  
-`cd mkdocs; rm -r docs site; mkdir docs; cp -r ../!(mkdocs) docs; cp style.css docs; mkdocs build; cd ..`  
+`cd mkdocs; ln -s .. docs; cp style.css ..; mkdocs build; cd ..; rm style.css`  
 MkDocs expects the Markdown documentation files to be in a "docs" subdirectory, so we create it and move everything to it, and then we can go ahead and build the site.

--- a/Home.md
+++ b/Home.md
@@ -69,4 +69,6 @@ So you are thinking of doing an engine control project. You have stopped by the 
 
 ### [![Miata rusEFI Racecar!](https://user-images.githubusercontent.com/5051341/80621997-bf7bf000-8a0d-11ea-998e-48fc3accba59.png)](https://www.youtube.com/embed/3xz66oR95F8?start=8 "Miata rusEFI Racecar!")
 
-### [![BMW V12 with dual ETB!](https://user-images.githubusercontent.com/5051341/80622501-809a6a00-8a0e-11ea-8efc-b575def1d132.png)](https://www.youtube.com/embed/TGf8IMwRuIY "BMW V12 with dual ETB!")
+### [![BMW V12 with dual ETB!](https://user-images.githubusercontent.com/5051341/80622501-809a6a00-8a0e-11ea-8efc-b575def1d132.png)](https://www.youtube.com/embed/TGf8IMwRuIY "BMW V12 with dual ETB!")  
+
+[Sitemap](sitemap.xml)

--- a/bin/mkdocs-install.sh
+++ b/bin/mkdocs-install.sh
@@ -1,10 +1,9 @@
 #!/bin/bash
 
 sudo apt update
-sudo apt install ncftp
 
 # sudo apt install python-pip for 'pip'
 sudo apt install python3-pip
 
 # pip did not work for  in my case?
-pip install mkdocs mkdocs-ezlinks-plugin
+pip install mkdocs mkdocs-ezlinks-plugin mkdocs-exclude

--- a/bin/mkdocs-run.sh
+++ b/bin/mkdocs-run.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
-shopt -s extglob
 cd mkdocs
-mkdir docs
-cp -r ../!(mkdocs) docs
-mkdocs build
+ln -s .. docs
+cp style.css ..
+mkdocs build --strict
+cd ..
+rm style.css

--- a/mkdocs/mkdocs.yaml
+++ b/mkdocs/mkdocs.yaml
@@ -9,6 +9,10 @@ plugins:
   - search
   - ezlinks:
       wikilinks: true
+  - exclude:
+      glob:
+        - mkdocs/*
+
 markdown_extensions:
   - sane_lists
   - md_in_html

--- a/mkdocs/mkdocs.yaml
+++ b/mkdocs/mkdocs.yaml
@@ -87,4 +87,3 @@ nav:
   - 'Misc':
     - 'How to convert from carburetor to EFI': how-to-convert-from-carburetor-to-EFI.md
     - 'Do I need a wideband oxygen sensor?': do-i-need-wideband-oxygen-sensor.md
-  - 'Sitemap': sitemap.xml


### PR DESCRIPTION
I also:
updated the scripts
added `--strict` parameter
moved the sitemap link from nav to the homepage to get rid of warning