### PR TITLE
Add instructions for editing locally

### DIFF
--- a/HOWTO-contribute-to-documentation.md
+++ b/HOWTO-contribute-to-documentation.md
@@ -28,6 +28,18 @@ In order to leverage the Github pull request process for access control to the w
 
 4. Once you are ready to contribute your changes, click the 'New pull request' button on the main page of your fork.
 
+### Alternative: Editing your fork locally
+
+If you are using Linux, macOS, or WSL on Windows, this is a good option because it allows you to test your changes.
+
+1. Fork the rusefi_documentation repo and clone it to your computer.
+
+2. Make your changes.
+
+3. [Test your changes](HOWTO-Test-Doc-Changes).
+
+4. Push your changes to your fork on Github, and create a pull request.
+
 ### After creating a Pull Request
 
 Within the next 5 minutes after the pull request has been merged, a Github Action automatically builds the wiki and uploads it to both wikis.


### PR DESCRIPTION
We needed a link to HOWTO-Test-Doc-Changes somewhere, so I added these instructions. I'm not sure if this is the best way to do things, but it's something.

I didn't put all the little details in these instructions, e.g. what command to run to clone to your computer. I figure that if they're already using Linux, macOS, or WSL, they probably don't need the hand-holding.