### PR TITLE
add permalinks - wiki3

### DIFF
--- a/mkdocs/mkdocs.yaml
+++ b/mkdocs/mkdocs.yaml
@@ -16,6 +16,8 @@ plugins:
 markdown_extensions:
   - sane_lists
   - md_in_html
+  - toc:
+      permalink: True
 
 extra_css:
   - style.css


### PR DESCRIPTION
Enable permalinks that appear when you hover over any header.
Linking to any header already worked, but there was no easy way to find out what the link should be. Now you can hover over a header, then hover over the paragraph icon that appears to get the link to that header.