### PR TITLE
fix content and links

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,19 +1,14 @@
 # rusEFI Documentation & Knowledge
 
-Documentation and knowledge repo for about [https://github.com/rusefi/rusefi](https://github.com/rusefi/rusefi)
+Documentation and knowledge repo for [https://github.com/rusefi/rusefi](https://github.com/rusefi/rusefi)
 
 If you are rusEFI end user, you are looking at the wrong page - you are probably interested in
-[https://github.com/rusefi/rusefi](https://github.com/rusefi/rusefi)/wiki
+[Wiki](https://wiki.rusefi.com/)
 
 If you are looking to change rusEFI documentation you are in the right place!
 
-This readme.md file is the main file visible at [https://github.com/rusefi/rusefi](https://github.com/rusefi/rusefi)_documentation
+See the following documents for more information
 
-home.md is the primary file for end-users if they use proper [https://github.com/rusefi/rusefi](https://github.com/rusefi/rusefi)/wiki URL
+- [HOWTO contribute to documentation](HOWTO-contribute-to-documentation.md)
 
-See [https://github.com/rusefi/rusefi](https://github.com/rusefi/rusefi)/wiki/HOWTO_contribute_to_documentation for more details
-
-[https://github.com/rusefi/rusefi](https://github.com/rusefi/rusefi)/wiki/Documentation_Workflow
-
-[https://github.com/rusefi/rusefi](https://github.com/rusefi/rusefi)/wiki/Documentation_Strategy
-
+- [Documentation Strategy](Documentation-Strategy.md)


### PR DESCRIPTION
*Remove "Documentation Workflow" because referenced file "https://github.com/rusefi/rusefi/wiki/Documentation_Workflow" does not exist and no replacement could be found 
(more **strange details**  in  https://github.com/rusefi/rusefi_documentation/issues/385)