### PR TITLE
massive to changes to brokenlinks script, etc.

### DIFF
--- a/Pages-Hardware.md
+++ b/Pages-Hardware.md
@@ -41,7 +41,7 @@
 
 <details><summary><u>PNP Boards</u></summary>
 
-* [PNP 48 - MRE based for Miata NA](/Hardware/pnp_microRusEFI_48na/microRusEFI48adapter_latest.pdf)
+* [PNP 48 - MRE based for Miata NA](Hardware/pnp_microRusEFI_48na/microRusEFI48adapter_latest.pdf)
 * [PNP 72 - MRE based for Miata NB2](Hardware/pnp_microRusEFI_nb2/hw72nb.pdf)
 * PNP 88 - Proteus based for 88pin Bosch - Coming Soon
 * [MRE Adapter 48](MREAdapter48)

--- a/check.txt
+++ b/check.txt
@@ -1,0 +1,49 @@
+# Bad Link Tests
+
+This file has some examples of good and bad link and image styles.
+
+[good link](Idle-Control)
+
+[bad link](Idle_Control)
+should be  Idle-Control
+
+[bad link](./Idle-Control)
+should be  Idle-Control
+
+[bad link](/Idle-Control)
+should be  Idle-Control
+
+[bad link](./Idle-Control.md)
+should be  Idle-Control
+
+[bad link](/Idle-Control.md)
+should be  Idle-Control
+
+[bad link](Idle-Control.md)
+should be  Idle-Control
+
+![good img](Images/Red_LED.png)
+
+![bad img](Images/Red-LED.png)
+should be  Images/Red_LED.png
+
+![bad img](Red_LED.png)
+should be  Images/Red_LED.png
+
+![bad img](Red_LED)
+should be  Images/Red_LED.png
+
+![bad img](Images/Red_LED)
+should be  Images/Red_LED.png
+
+![bad img](./Images/Red_LED.png)
+should be  Images/Red_LED.png
+
+![bad img](./Images/Red_LED)
+should be  Images/Red_LED.png
+
+![bad img](/Images/Red_LED.png)
+should be  Images/Red_LED.png
+
+![bad img](/Images/Red_LED)
+should be  Images/Red_LED.png

--- a/check.txt
+++ b/check.txt
@@ -22,6 +22,15 @@ should be  Idle-Control
 [bad link](Idle-Control.md)
 should be  Idle-Control
 
+[bad link](Idle-Control.md#valve-initialization)
+should be  Idle-Control#valve-initialization
+
+[bad link](Idle-Control#Valve-initialization)
+should be  Idle-Control#valve-initialization
+
+[bad link](Idle-Control#valve_initialization)
+should be  Idle-Control#valve-initialization
+
 ![good img](Images/Red_LED.png)
 
 ![bad img](Images/Red-LED.png)

--- a/wiki-tools/brokenlinks.sh
+++ b/wiki-tools/brokenlinks.sh
@@ -4,6 +4,7 @@
 #                                           02/18/2021                                           #
 #                                   Written By David Holdeman                                    #
 #     Searches for broken links in a Github Wiki repo, and suggests and applies corrections.     #
+#          Usage: brokenlinks.sh [-s non-interactive] [-d debug] <optional file(s)> ...          #
 ##################################################################################################
 
 # These two functions are used to escape variables for use in a sed command
@@ -174,6 +175,9 @@ searchfile() {
     if [ -n "$HASH" ] && [ "$URLSTATUS" -eq 0 ]; then
       checkhash "$1" "$HASH" "$URL"
     fi
+    if [ "$DEBUG" -eq 1 ]; then
+      echo "$(date +%T.%N)	$1	$URL	$HASH"
+    fi
   # This regex finds links in the file that is passed to searchfile
   # Results are fed to file descriptor 3 for the reasons previously explained.
   done 3< <(grep -oP '(?<=\]\().*?(?=[\)])' "$1" | sed -e "s/^<//g" -e "s/>$//g" | cut -d '"' -f1 | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
@@ -183,9 +187,12 @@ export -f searchfile
 FILES=()
 
 export SCRIPT=0
+export DEBUG=0
 for i in $@; do
   if [ "$i" == "-s" ]; then
     export SCRIPT=1
+  elif [ "$i" == "-d" ]; then
+    export DEBUG=1
   else
     FILES+=("${i}")
   fi

--- a/wiki-tools/brokenlinks.sh
+++ b/wiki-tools/brokenlinks.sh
@@ -175,7 +175,7 @@ for i in $@; do
   fi
 done
 
-export LIST=$(find . -iname "*.md")
+export LIST=$(find . -iname "*.md" ! -name '_*')
 
 if [ "${#FILES[@]}" -gt 0 ]; then
   for f in "${FILES[@]}"; do

--- a/wiki-tools/brokenlinks.sh
+++ b/wiki-tools/brokenlinks.sh
@@ -72,9 +72,9 @@ checkurl() {
   # Build the search term we will look for.
   # All hyphens and underscores are replaced with asterisks, so we
   #   can find files with mismatched hyphens or underscores.
-  SEARCH='.*'$(basename "$LINK" | sed 's/[-_ ]/.*/g')'.*'
+  SEARCH='*'$(basename "$LINK" | sed 's/[-_ ]/*/g')'*'
   # Search for matching files.
-  FILES=$(echo "$LIST" | grep -i "$SEARCH")
+  FILES=$(find . -iname "$SEARCH")
   (
   flock -x 200
   # Print the filename and the broken link.
@@ -103,7 +103,7 @@ checkurl() {
     # Parentheses are placed around both the old link and new one in order to ensure we replace the link,
     #   and not some other place in the file that happens to use the same words.
     REPLACE=$(escape '('"$LINK""$HASH"')')
-    REPLACEWITH=$(escapeReplace "$(basename "$FILE" .md)$HASH")
+    REPLACEWITH=$(escapeReplace "$FILE""$HASH")
     sed -i "s/$REPLACE/\($REPLACEWITH\)/" "$1"
     # print the URL for use in checkhash
     echo "$LINK"

--- a/wiki-tools/brokenlinks.sh
+++ b/wiki-tools/brokenlinks.sh
@@ -57,7 +57,7 @@ checkurl() {
     ) 200>brokenlinks.lock
   fi
   # Skip links that are to an .md file and aren't broken.
-  if [ "$(find . -name "$2"".md" 2>/dev/null | wc -l)" -gt 0 ]; then
+  if [ "$(echo "$LIST" | grep "$2"".md" 2>/dev/null | wc -l)" -gt 0 ]; then
     # print the URL for use in checkhash
     echo "$2"
     return 0
@@ -191,11 +191,13 @@ for i in $@; do
   fi
 done
 
+export LIST=$(find . -iname "*.md")
+
 if [ "${#FILES[@]}" -gt 0 ]; then
   for f in "${FILES[@]}"; do
     searchfile "$f"
   done
 else
   # run searchfile on every .md file in the repo
-  xargs -0 -P $(nproc --all) -a <(find . -iname "*.md" -print0) -I {} bash -c 'searchfile "$@"' _ {}
+  xargs -0 -P $(nproc --all) -a <(echo "$LIST" | tr '\n' '\0') -I {} bash -c 'searchfile "$@"' _ {}
 fi

--- a/wiki-tools/brokenlinks.sh
+++ b/wiki-tools/brokenlinks.sh
@@ -74,9 +74,9 @@ checkurl() {
     # Build the search term we will look for.
     # All hyphens and underscores are replaced with asterisks, so we
     #   can find files with mismatched hyphens or underscores.
-    SEARCH='*'$(basename "$2" | sed 's/[-_ ]/*/g')'*'
+    SEARCH='.*'$(basename "$2" | sed 's/[-_ ]/.*/g')'.*'
     # Search for matching files.
-    FILES=$(find . -iname "$SEARCH")
+    FILES=$(echo "$LIST" | grep -i "$SEARCH")
     (
     flock -x 200
     # Print the filename and the broken link.
@@ -112,9 +112,9 @@ checkurl() {
   # Build the search term we will look for.
   # All hyphens and underscores are replaced with asterisks, so we
   #   can find files with mismatched hyphens or underscores.
-  SEARCH='*'$(basename "$2" | sed 's/[-_ ]/*/g')'*'
+  SEARCH='.*'$(basename "$2" | sed 's/[-_ ]/.*/g')'.*'
   # Search for matching files.
-  FILES=$(find . -iname "$SEARCH")
+  FILES=$(echo "$LIST" | grep -i "$SEARCH")
   (
   flock -x 200
   echo "In $1:" >&2

--- a/wiki-tools/brokenlinks.sh
+++ b/wiki-tools/brokenlinks.sh
@@ -45,6 +45,7 @@ checkurl() {
     # Print the options as though they are a list in order to have the same UI as other types of correction
     echo "$LINK" | cat --number >&2
     if [ "$SCRIPT" -lt 1 ]; then
+      echo "Type a number, then hit return to select an alternative, or just hit return to skip fixing:" >&2
       # Read the user input
       read -r PICK
       if [ "$PICK" -eq 1 ]; then
@@ -88,6 +89,7 @@ checkurl() {
   # List the potential files, with numbers.
   echo "$FILES" | cat --number >&2
   if [ "$SCRIPT" -lt 1 ]; then
+    echo "Type a number, then hit return to select an alternative, or just hit return to skip fixing:" >&2
     # Read the user input
     read -r PICK
     # If the selection isn't a number, skip to the next link.

--- a/wiki-tools/brokenlinks.sh
+++ b/wiki-tools/brokenlinks.sh
@@ -98,7 +98,9 @@ checkurl() {
     fi
     # Get the selected file path, without the preceding ./
     FILE=$(echo "$FILES" | head -n "$PICK" | tail -n 1 | sed 's/^\.\///')
+    MD=0
     if echo "$FILE" | grep ".md$" >/dev/null; then
+      MD=1
       FILE=$(basename "$FILE" .md)
     fi
     # Replace the old link with the new one.
@@ -109,7 +111,11 @@ checkurl() {
     sed -i "s/$REPLACE/\($REPLACEWITH\)/" "$1"
     # print the URL for use in checkhash
     echo "$LINK"
-    return 0
+    if [ "$MD" -eq 1 ]; then
+      return 0
+    else
+      return 2
+    fi
   fi
   return 1
   ) 200>brokenlinks.lock

--- a/wiki-tools/lint.sh
+++ b/wiki-tools/lint.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
 STATUS=0
 CHANGED=$(git diff --name-only HEAD HEAD~1 | grep -v '^_' | grep '.md$')
-if [ "$CHANGED" == "" ]; then
-  exit 0
+if [ -n "$CHANGED" ]; then
+  markdownlint -i '_*' --disable MD033 MD034 MD013 MD024 MD036 -- $CHANGED
 fi
-markdownlint -i '_*' --disable MD033 MD034 MD013 MD024 MD036 -- $CHANGED
 if [ "$?" -gt 0 ]; then
   STATUS=1
 fi

--- a/wiki-tools/lint.sh
+++ b/wiki-tools/lint.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 STATUS=0
-CHANGED=$(git diff --name-only HEAD HEAD~1 | grep -v '^_' | grep '.md$')
+CHANGED=$(git diff --name-only HEAD~1 HEAD | grep -v '^_' | grep '.md$')
 if [ -n "$CHANGED" ]; then
   markdownlint -i '_*' --disable MD033 MD034 MD013 MD024 MD036 -- $CHANGED
 fi

--- a/wiki-tools/lint.sh
+++ b/wiki-tools/lint.sh
@@ -18,5 +18,4 @@ else
   bash wiki-tools/brokenlinks.sh -s $CHANGED
 fi
 
-
-return "$STATUS"
+exit "$STATUS"

--- a/wiki-tools/lint.sh
+++ b/wiki-tools/lint.sh
@@ -1,6 +1,17 @@
 #!/usr/bin/env bash
+STATUS=0
 CHANGED=$(git diff --name-only HEAD HEAD~1 | grep -v '^_' | grep '.md$')
 if [ "$CHANGED" == "" ]; then
   exit 0
 fi
 markdownlint -i '_*' --disable MD033 MD034 MD013 MD024 MD036 -- $CHANGED
+if [ "$?" -gt 0 ]; then
+  STATUS=1
+fi
+
+bash wiki-tools/brokenlinks.sh -s
+if [ "$?" -gt 0 ]; then
+  STATUS=1
+fi
+
+return "$STATUS"

--- a/wiki-tools/lint.sh
+++ b/wiki-tools/lint.sh
@@ -9,9 +9,14 @@ if [ "$?" -gt 0 ]; then
   STATUS=1
 fi
 
-bash wiki-tools/brokenlinks.sh -s
-if [ "$?" -gt 0 ]; then
-  STATUS=1
+if git diff --compact-summary HEAD~1 HEAD | grep -E "=>|\(new\)" >/dev/null; then
+  bash wiki-tools/brokenlinks.sh -s
+  if [ "$?" -gt 0 ]; then
+    STATUS=1
+  fi
+else
+  bash wiki-tools/brokenlinks.sh -s $CHANGED
 fi
+
 
 return "$STATUS"

--- a/wiki-tools/lint.sh
+++ b/wiki-tools/lint.sh
@@ -15,6 +15,9 @@ if git diff --compact-summary HEAD~1 HEAD | grep -E "=>|\(new\)" >/dev/null; the
   fi
 else
   bash wiki-tools/brokenlinks.sh -s $CHANGED
+  if [ "$?" -gt 0 ]; then
+    STATUS=1
+  fi
 fi
 
 exit "$STATUS"


### PR DESCRIPTION
- Brokenlinks Script
  - Performance Enhancements
    - Simultaneous multithreading
    - Storing list of .md files so it doesn't have to run `find` for every link
  - prompt instructing user how to fix link
  - more comments
  - usage note at top of script
  - debug flag that prints time, file, url, and hash fragment
  - fix dumb way of doing things due to the script being thrown together
  - ignore _Sidebar.md and _Footer.md
  - ...so that we can correct links starting with '/'
- Now runs brokenlinks.sh on PRs
  - only checks changed files
  - unless a file was added, removed, or renamed, then it checks everything
  - in my testing, takes 15-25 seconds when checking everything
- check.txt file for examples of bad links and images
- fix 1 broken link found by checking links starting with '/'