### PR TITLE
Revert "Fix typo and bold syntax"

### DIFF
--- a/HOWTO-quick-start.md
+++ b/HOWTO-quick-start.md
@@ -69,7 +69,7 @@ Turn on the ignition. DO NOT START THE CAR
 ### Step 4
 
 Connect TunerStudio to your ECU.
-With this your TunerStudio screen should come to life! You should see sensor inputs and some output values like ignition timing and dwell. If things are set up properly, you should see reasonable values for [Coolant temperature], [Air Intake temperature], [Battery Voltage], [Manifold Air Pressure] (should be near 100kpa if you're using a MAP sensor) and even your [throttle pedal position]. The values may show some jitters. Your rpms should be 0. Push your throttle pedal and see if you get a response. Congratulations- your rusEFI can "see" your car.
+With this your TunerStudio screen should come to life! You should see sensor inputs and some output values like ignition timing and dwell. If things are set up properly, you should see reasonable values for [Coolant temperature], [Air Intake temperature], [Battery Voltage], [Manifold Air Pressure] (should be near 100kpa if you're using a MAP snesor) and even your [throttle pedal position]. The values may show some jitters. Your rpms should be 0. Push your throttle pedal and see if you get a response. Congratulations- your rusEFI can "see" your car.
 
 ### Step 5
 
@@ -81,7 +81,7 @@ Test your outputs. Under "Controller" -> "Bench Test & Commands" you can see a l
 
 Then move on to spark. Here it depends on how your car is set up. If you have a 4-cylinder with wasted spark (which is likely the majority of users), you will likely be using "Spark #1" and "Spark #3". When you click the test button, you should hear the corresponding ignition coil firing. If you can't hear the spark, you may want to pull a spark plug (or use a spare) and hook it up to the spark plug connector and ground it. Test again and you should see a spark arcing. Dont shock yourself.
 
-Now it's time to test your injectors. Again, this depends on your vehicle. Most cars will at least have two banks of injectors. So you should definitely hear injectors firing when you're testing "Injector #1" and "Injector #2". If you have full-sequential fuel, you should try as many injectors as your engine has cylinders. **Fuel is flammable. Have a fire extinguisher near by just in case.**
+Now it's time to test your injectors. Again, this depends on your vehicle. Most cars will at least have two banks of injectors. So you should definitely hear injectors firing when you're testing "Injector #1" and "Injector #2". If you have full-sequential fuel, you should try as many injectors as your engine has cylinders. *Fuel is flammable. Have a fire extinguisher near by just in case.
 
 That's the basic outputs tested. With this you should be able to get the engine to run. You can go ahead and test the other outputs as well. Like Check Engine Light. Engine-Fan, AC, AC-Fan etc.
 


### PR DESCRIPTION
Reverts rusefi/rusefi_documentation#412

to fix conflict in:
[improve "Quick start" howto #413](https://github.com/rusefi/rusefi_documentation/pull/413)