### PR TITLE
fix VVT page list MD007

### DIFF
--- a/VVT.md
+++ b/VVT.md
@@ -1,20 +1,21 @@
 # VVT: Variable Valve Timing
 
 rusEFI has proper closed-loop VVT control, supporting multiple trigger options including:
- - "one-tooth"
- - Mazda Miata NB (2nd generation)
- - Mazda Skyactive
- - Toyota 2JZ family
- - Bosch Quick Start
- - Ford Focus ST 170
- - Ford Barra: 3+1
- - Nissan VQ family
- - Nissan MR18
- - Honda K family
- - Mitsubishi 3A92
- - Mitsubishi 4G92/93/94
- - Mitsubishi 4G63
- - Mitsubishi 6G75
+
+- "one-tooth"
+- Mazda Miata NB (2nd generation)
+- Mazda Skyactive
+- Toyota 2JZ family
+- Bosch Quick Start
+- Ford Focus ST 170
+- Ford Barra: 3+1
+- Nissan VQ family
+- Nissan MR18
+- Honda K family
+- Mitsubishi 3A92
+- Mitsubishi 4G92/93/94
+- Mitsubishi 4G63
+- Mitsubishi 6G75
 
 At the moment rusEFI has only one channel of VVT position input.
 


### PR DESCRIPTION
I guess maybe the linter wasn't wrong: apparently you cannot have leading spaces in a bulleted list