### PR TITLE
use separate links for release and nightly

### DIFF
--- a/Download.md
+++ b/Download.md
@@ -37,9 +37,11 @@ Please double check the version before updating your firmware, or your settings 
 
 ## Advanced
 
-[Older Releases](https://github.com/rusefi/rusefi/releases/)
+[Older Releases](https://github.com/rusefi/rusefi/releases?q=prerelease%3Afalse)
 
-[Snapshot builds](https://rusefi.com/build_server/)
+[Nightly Builds](https://github.com/rusefi/rusefi/releases?q=prerelease%3Atrue)
+
+[Snapshot Builds](https://rusefi.com/build_server/)
 
 **[Quick Start](HOWTO-quick-start)**
 


### PR DESCRIPTION
Github [just fixed](https://github.com/orgs/community/discussions/6108#discussioncomment-5973413) the prerelease filter on the releases page, so we can have a link for releases, and a separate link for nightly builds.