### PR TITLE
Replace wiki2 links with relative MD links

### DIFF
--- a/Dev-Quick-Start.md
+++ b/Dev-Quick-Start.md
@@ -24,7 +24,7 @@ See also <https://github.com/rusefi/rusefi/blob/master/firmware/setup_linux_envi
 
 ## Unit Tests
 
-We are heavy in CI/CD so https://github.com/rusefi/rusefi/wiki/Dev-Quality-Control and https://github.com/rusefi/rusefi/blob/master/unit_tests/readme.md
+We are heavy in CI/CD so [Dev Quality Control](dev-hardware-quality-control) and https://github.com/rusefi/rusefi/blob/master/unit_tests/readme.md
 
 ## GitHub Actions
 

--- a/GDI8.md
+++ b/GDI8.md
@@ -2,11 +2,11 @@
 
 https://rusefi.com/docs/pinouts/GDI8/
 
-🔴 Community support ONLY 🔴 [Support Statement](https://github.com/rusefi/rusefi/wiki/Support) 🔴 [Facebook group](https://www.facebook.com/groups/rusEfi) 🔴 [Discord](https://github.com/rusefi/rusefi/wiki/Discord) 🔴
+🔴 Community support ONLY 🔴 [Support Statement](Support) 🔴 [Facebook group](https://www.facebook.com/groups/rusEfi) 🔴 [Discord](Discord) 🔴
 
 * 8 injectors
 * two HPFP (same as with injectors, it's the external ECU which is responsible for pressure build up control)
 * CAN bus to adjust settings
-* many specs match https://github.com/rusefi/rusefi/wiki/GDI4 - this board is two GDI4 glued together
+* many specs match [GDI4](GDI4) - this board is two GDI4 glued together
 * WARNING: main ECU firmware supports only one HPFP!
 * WARNING: overall limited integration with main ECU. See https://github.com/rusefi/rusefi/blob/master/firmware/controllers/lua/examples/gdi8-pressure-input.lua https://github.com/rusefi/rusefi/blob/master/firmware/controllers/lua/examples/gdi4-communication.lua

--- a/GM-E38.md
+++ b/GM-E38.md
@@ -14,7 +14,7 @@ A standalone compatible with GM E38 pinout [💲available at the rusEFI store�
 
 https://github.com/rusefi/e38-e67-customer-support
 
-🔴Community support ONLY 🔴 https://www.facebook.com/groups/rusEfi 🔴 [Discord](https://github.com/rusefi/rusefi/wiki/Discord)🔴
+🔴Community support ONLY 🔴 https://www.facebook.com/groups/rusEfi 🔴 [Discord](Discord)🔴
 
 ## Specs
 

--- a/GM.md
+++ b/GM.md
@@ -68,15 +68,15 @@ https://rusefi.com/docs/pinouts/E92-blue-adapter/
 
 https://en.wikipedia.org/wiki/GM_Ecotec_engine#Generation_III
 
-https://github.com/rusefi/rusefi/wiki/Gen-5-LS
+[E38](GM-E38)
 
-https://github.com/rusefi/rusefi/wiki/GM-E38
+[E67](GM-E67)
 
-https://github.com/rusefi/rusefi/wiki/GM-E67
+[Gen 3 LS](Gen-3-LS)
 
-https://github.com/rusefi/rusefi/wiki/Gen-3-LS
+[Gen 4 LS](Gen-4-LS)
 
-https://github.com/rusefi/rusefi/wiki/Gen-4-LS
+[Gen 5 LS](Gen-5-LS)
 
 ![image](https://github.com/user-attachments/assets/ee53759f-6f63-473f-8b5a-b23460d5d303)
 

--- a/Gen-4-LS.md
+++ b/Gen-4-LS.md
@@ -1,8 +1,8 @@
 # Gen 4 LS
 
-<https://github.com/rusefi/rusefi/wiki/GM-E38>
+[E38](GM-E38)
 
-<https://github.com/rusefi/rusefi/wiki/GM-E67>
+[E67](GM-E67)
 
 73+80   e38 ECM, used 07-14 trucks/suv
 
@@ -24,7 +24,7 @@ If I had to make an educated guess, GM used the E67 for their GMPP (GM Performan
 
 ## e67
 
-<https://github.com/rusefi/rusefi/wiki/GM-E67>
+[E67](GM-E67)
 
 ## e38 2007 Tahoe 5.3
 

--- a/HOWTO-GDI-flow-bench-using-rusEFI-GDI4.md
+++ b/HOWTO-GDI-flow-bench-using-rusEFI-GDI4.md
@@ -2,6 +2,6 @@
 
 PC software https://www.efianalytics.com/TunerStudio/beta/
 
-Documentation https://github.com/rusefi/rusefi/wiki/GDI4
+[Documentation](GDI4)
 
 Pinout https://rusefi.com/docs/pinouts/GDI4/

--- a/HOWTO-custom-harness-lazyharnezz-M73.md
+++ b/HOWTO-custom-harness-lazyharnezz-M73.md
@@ -70,7 +70,7 @@ M70 style three pin
 
 ## WBO
 
-https://github.com/rusefi/rusefi/wiki/WBO#sensor-part-numbers
+[Sensor Part Numbers](WBO#sensor-part-numbers)
 
 ## 8 pin plug
 
@@ -82,7 +82,7 @@ Green Fan LS15
 
 ## Pedal
 
-Many pedals would work if you wire, one popular sensor mounted on many different Toyota and Nissan vehicles see https://github.com/rusefi/rusefi/wiki/Vault-Of-Electronic-Throttle-Bodies-ETB#nissan-pedal
+Many pedals would work if you wire, one popular sensor mounted on many different Toyota and Nissan vehicles see [Nissan Pedal](Vault-Of-Electronic-Throttle-Bodies-ETB#nissan-pedal)
 
 ## Integration
 

--- a/HOWTO-upload-tune.md
+++ b/HOWTO-upload-tune.md
@@ -14,7 +14,7 @@ Now you are ready to hit "Upload" button on [https://rusefi.com/online/](https:/
 
 ### A: If you want to mention a tune please provide exact URL. It's not very useful to just say "I've uploaded my tune" without full URL. Please help us help you by pointing at what _exactly_ we are looking to discuss :)
 
-See also <https://github.com/rusefi/rusefi/wiki/HOWTO-upload-log>
+See also [How To Upload Log](HOWTO-upload-log)
 
 ## Q: Why bother?
 

--- a/Hardware.md
+++ b/Hardware.md
@@ -2,7 +2,7 @@
 
 As of 2025 we are selling eight universal ECUs. See [Mission-Statement](Mission-Statement)
 
-🔴 Community support ONLY 🔴 [Support Statement](https://github.com/rusefi/rusefi/wiki/Support) 🔴 [Facebook group](https://www.facebook.com/groups/rusEfi) 🔴 [Discord](https://github.com/rusefi/rusefi/wiki/Discord) 🔴
+🔴 Community support ONLY 🔴 [Support Statement](Support) 🔴 [Facebook group](https://www.facebook.com/groups/rusEfi) 🔴 [Discord](Discord) 🔴
 
 [⏩ 2025 universal hardware matrix ⏪](https://docs.google.com/spreadsheets/d/1HJYltK4RPDa0RIg4GWNU_2hYVAgdOU0GPiVdebtVTzo)
 
@@ -24,7 +24,7 @@ Unified rusEFI firmware runs on a wide array of boards with stm32f4 and stm32f7 
 A: At rusEFI we love cool new projects, but we are a really small team and only have so much time to work on rusEFI.  
 We already have lots of different hardware configurations and we would suggest using one of the existing wire in versions.  
 Nobody is stopping you from making your own board, but we cannot guarantee any support for that board or assistance with building it.  
-If you proceed then please consider making a P&P adapter board design based on [Hellen](Hellen-One-Platform), [Proteus](https://github.com/mck1117/proteus/), or microRusEFI. See also https://github.com/rusefi/rusefi/wiki/Custom-Firmware
+If you proceed then please consider making a P&P adapter board design based on [Hellen](Hellen-One-Platform), [Proteus](https://github.com/mck1117/proteus/), or microRusEFI. See also [Custom Firmware](Custom-Firmware)
 
 ## Q: What EDA are you guys using for your open source hardware?
 

--- a/Harley-81.md
+++ b/Harley-81.md
@@ -4,7 +4,7 @@
 
 [Interactive BOM](https://rusefi.com/docs/ibom/hellen81hd-a-ibom.html)
 
-[Vehicle Pinout](https://github.com/rusefi/rusefi/wiki/Harley-Davidson#2021)
+[Vehicle Pinout](Harley-Davidson#2021)
 
 ![x](OEM-Docs/Harley/Harley-Touring-2021-ecu-1.png)
 

--- a/Lua-Scripting.md
+++ b/Lua-Scripting.md
@@ -11,7 +11,7 @@ rusEFI strives to offer users as much flexibility as possible, to provide a comp
 rusEFI provides a number of hooks to interface with the firmware and to manipulate its state and read/write the current configuration.
 
 - Hooks for CAN bus communications; see [CAN bus](#can-bus).
-- Inputs from sensors can be read directly; see [Input](#input). You can also produce sensor values with Lua see https://github.com/rusefi/rusefi/wiki/Lua-Scripting#set-sensor-value
+- Inputs from sensors can be read directly; see [Input](#input). You can also produce sensor values with Lua see [Set Sensor Value](Lua-Scripting#set-sensor-value)
 - ECU general purpose outputs see [Output](#output).
 - Aspects of the engine can be controlled directly; see [Engine Control](#engine-control).
 - ECU Configurations can be accessed (read/write) via the [`getCalibration()`](#getcalibrationname) hook, and manipulated via the [`setCalibration()`](#setcalibrationname-value-needevent) hook.

--- a/Mercedes.md
+++ b/Mercedes.md
@@ -1,7 +1,7 @@
 # Mercedes
 
-https://github.com/rusefi/rusefi/wiki/Hellen-128-Mercedes is the easiest option if your vehicle has matching harness (ME 2.0/2.1)
+[Hellen 128 Mercedes](Hellen-128-Mercedes) is the easiest option if your vehicle has matching harness (ME 2.0/2.1)
 
-https://github.com/rusefi/rusefi/wiki/microRusEFI-Manual smaller universal ECU should be enough for 4 cylinder applications, harness modification required.
+[microRusEFI](microRusEFI-Manual) smaller universal ECU should be enough for 4 cylinder applications, harness modification required.
 
-https://github.com/rusefi/rusefi/wiki/Proteus-Manual has enough outputs to handle even simpler 12 cylinder engines, harness modification required.
+[Proteus](Proteus-Manual) has enough outputs to handle even simpler 12 cylinder engines, harness modification required.

--- a/Nissan.md
+++ b/Nissan.md
@@ -12,4 +12,4 @@ https://docs.google.com/spreadsheets/d/1xH6szt3SJB7AzoseS9kyFPDHr-XMuRVpYXs7gHTQ
 
 ## 121 pin
 
-https://github.com/rusefi/rusefi/wiki/Hellen-121-Nissan
+[Hellen 121 Nissan](Hellen-121-Nissan)

--- a/Overview.md
+++ b/Overview.md
@@ -1,3 +1,3 @@
 # Overview
 
-[Moved to Home](https://github.com/rusefi/rusefi/wiki)
+[Moved to Home](Home)

--- a/Power4GDI.md
+++ b/Power4GDI.md
@@ -2,7 +2,7 @@
 
 Basic standalone ECU for 4 cylinder GDI engines - please double-check pinout, this unit could be short on IO for some of the more advanced 4 cylinder engines.  Available at [💲rusEFI store💲](https://www.shop.rusefi.com/shop/p/gdi4ecu)
 
-🔴 Community support ONLY 🔴 [Support Statement](https://github.com/rusefi/rusefi/wiki/Support) 🔴 [Facebook group](https://www.facebook.com/groups/rusEfi) 🔴 [Discord](https://github.com/rusefi/rusefi/wiki/Discord) 🔴
+🔴 Community support ONLY 🔴 [Support Statement](Support) 🔴 [Facebook group](https://www.facebook.com/groups/rusEfi) 🔴 [Discord](Discord) 🔴
 
 [New to rusEFI start here](Home)
 
@@ -21,4 +21,4 @@ Basic standalone ECU for 4 cylinder GDI engines - please double-check pinout, th
 
 ##
 
-[Kia PB adapter](https://rusefi.com/docs/pinouts/Hyundai-Kia-PB-platform-adapter/) see also [Hyundai-PB](https://github.com/rusefi/rusefi/wiki/Hellen-Hyundai-PB)
+[Kia PB adapter](https://rusefi.com/docs/pinouts/Hyundai-Kia-PB-platform-adapter/) see also [Hyundai-PB](Hellen-Hyundai-PB)

--- a/Proteus-Honda125.md
+++ b/Proteus-Honda125.md
@@ -8,6 +8,6 @@
 
 [Proteus Manual](Proteus-Manual)
 
-[see also Hellen-125-Honda-K](https://github.com/rusefi/rusefi/wiki/Hellen-125-Honda-K)
+[see also Hellen-125-Honda-K](Hellen-125-Honda-K)
 
 ![x](https://rusefi.com/forum/download/file.php?id=8391)

--- a/Proteus-Manual.md
+++ b/Proteus-Manual.md
@@ -2,13 +2,13 @@
 
 Our older fully-featured larger ECU available at [💲rusEFI store💲](https://www.shop.rusefi.com/shop/p/spring-blade-cyy7n)
 
-🔴 Community support ONLY 🔴 [Support Statement](https://github.com/rusefi/rusefi/wiki/Support) 🔴 [Facebook group](https://www.facebook.com/groups/rusEfi) 🔴 [Discord](https://github.com/rusefi/rusefi/wiki/Discord) 🔴
+🔴 Community support ONLY 🔴 [Support Statement](Support) 🔴 [Facebook group](https://www.facebook.com/groups/rusEfi) 🔴 [Discord](Discord) 🔴
 
 [New to rusEFI start here](Home)
 
 [Proteus Release Software](https://github.com/rusefi/rusefi/releases/latest/download/rusefi_bundle_proteus_f7.zip)
 [Proteus Beta Snapshot](https://rusefi.com/build_server/rusefi_bundle_proteus_f7.zip)
-[Release vs Snapshot](https://github.com/rusefi/rusefi/wiki/Release-Snapshot-Latest-firmware)
+[Release vs Snapshot](Release-Snapshot-Latest-firmware)
 
 ## Specs
 

--- a/Rotary.md
+++ b/Rotary.md
@@ -1,6 +1,6 @@
 # Rotary Engines
 
-TL,DR: they say we totally support rotary on [all our universal ECUs](https://github.com/rusefi/rusefi/wiki/Hardware). As of September 2025 rusEFI has tested trailing coil logic.
+TL,DR: they say we totally support rotary on [all our universal ECUs](Hardware). As of September 2025 rusEFI has tested trailing coil logic.
 
 A lot of sweet TODO at [https://github.com/rusefi/rusefi/issues/3247](https://github.com/rusefi/rusefi/issues/3247)
 

--- a/Royalty.md
+++ b/Royalty.md
@@ -6,4 +6,4 @@ You can fabricate hardware and sell for profit without paying royalties as long 
 
 ## Donations
 
-rusEFI LLC definitely has expenses so your donations would be appreciated! One-time, monthly or fixed amount per board would all help. See https://github.com/rusefi/rusefi/wiki/HOWTO-help-rusEFI#last-but-not-least
+rusEFI LLC definitely has expenses so your donations would be appreciated! One-time, monthly or fixed amount per board would all help. See [HOWTO help rusEFI](HOWTO-help-rusEFI#last-but-not-least)

--- a/Small-CAN-Board.md
+++ b/Small-CAN-Board.md
@@ -6,7 +6,7 @@
 
 [firmware snapshot bundle](https://rusefi.com/build_server/rusefi_bundle_small-can-board.zip)
 
-Build your own CANbus driven smart wastegate controller or control axillary lights on a modern vehicle or whatever you need leveraging the wide range of available input-outputs, all leveraging the power of [Lua scripting](https://github.com/rusefi/rusefi/wiki/Lua-Scripting)!
+Build your own CANbus driven smart wastegate controller or control axillary lights on a modern vehicle or whatever you need leveraging the wide range of available input-outputs, all leveraging the power of [Lua scripting](Lua-Scripting)!
 
 * Full rusEFI firmware with Lua running stm32f405 LQFP-64
 * Two CAN buses

--- a/TS-over-CAN.md
+++ b/TS-over-CAN.md
@@ -4,7 +4,7 @@ rusEFI TS communication could go over CAN wires. Definitely much slower than USB
 
 As of today TunerStudio does not communicate with CAN dongles directly - so, we have a rusEFI own proxy software with ISO/TP on CAN dongle side, and TCP/IP for TunerStudio .
 
-Step 1: have relevant hardware: PCAN for Windows or SocketCAN for Unix see <https://github.com/rusefi/rusefi/wiki/CAN#hardware-options>
+Step 1: have relevant hardware: PCAN for Windows or SocketCAN for Unix see [CAN hardware options](CAN#hardware-options)
 
 Step 2: in bundle bin folder execute pcan_connector.bat or socketcan_connector.sh
 

--- a/Trigger-Configuration-Guide.md
+++ b/Trigger-Configuration-Guide.md
@@ -76,6 +76,6 @@ ToDo: add correct polarity scope image
 
 Now the "bad edge" of the missing tooth is a rising edge, and the good tooth centers are falling edges, which output a digital rising edge to the ECU.
 
-See also https://github.com/rusefi/rusefi/wiki/Trigger#troubleshooting-with-ts-logs
+See also [Troubleshooting with TS logs](Trigger#troubleshooting-with-ts-logs)
 
 See also [How-Do-I-Set-My-Trigger-Offset](How-Do-I-Set-My-Trigger-Offset)

--- a/VVT.md
+++ b/VVT.md
@@ -33,4 +33,4 @@ For example, 3/1 skipped wheel with cam sensor in the first half of the 720 cycl
 
 ![VVT Config](Images/VVT_config.png)
 
-Full list see https://github.com/rusefi/rusefi/wiki/All-Supported-Triggers
+Full list see [All Supported Triggers](All-Supported-Triggers)

--- a/Volkswagen.md
+++ b/Volkswagen.md
@@ -6,7 +6,7 @@ https://rusefi.com/docs/pinouts/hellen/Passat-2.0-MED9.1/
 
 https://rusefi.com/docs/pinouts/MED9.1%20Adapter/
 
-https://github.com/rusefi/rusefi/wiki/VolkswagenPassatB6
+[VolkswagenPassatB6](VolkswagenPassatB6)
 
 ## ME17
 

--- a/microRusEFI-Manual.md
+++ b/microRusEFI-Manual.md
@@ -2,13 +2,13 @@
 
 Our older fully-featured larger ECU available at [💲rusEFI store💲](https://www.shop.rusefi.com/shop/p/microrusefi-assembled-ecu-development-module)
 
-🔴 Community support ONLY 🔴 [Support Statement](https://github.com/rusefi/rusefi/wiki/Support) 🔴 [Facebook group](https://www.facebook.com/groups/rusEfi) 🔴 [Discord](https://github.com/rusefi/rusefi/wiki/Discord) 🔴
+🔴 Community support ONLY 🔴 [Support Statement](Support) 🔴 [Facebook group](https://www.facebook.com/groups/rusEfi) 🔴 [Discord](https://github.com/rusefi/rusefi/wiki/Discord) 🔴
 
 [New to rusEFI start here](Home)
 
 [microRusEFI Release Software](https://github.com/rusefi/rusefi/releases/latest/download/rusefi_bundle_mre_f4.zip)
 [microRusEFI Beta Snapshot](https://rusefi.com/build_server/rusefi_bundle_mre_f4.zip)
-[Release vs Snapshot](https://github.com/rusefi/rusefi/wiki/Release-Snapshot-Latest-firmware)
+[Release vs Snapshot](Release-Snapshot-Latest-firmware)
 
 ## Specs
 

--- a/nano.md
+++ b/nano.md
@@ -2,13 +2,13 @@
 
 Out smallest universal ECU available at [💲rusEFI store💲](https://www.shop.rusefi.com/shop/p/nano)
 
-🔴 Community support ONLY 🔴 [Support Statement](https://github.com/rusefi/rusefi/wiki/Support) 🔴 [Facebook group](https://www.facebook.com/groups/rusEfi) 🔴 [Discord](https://github.com/rusefi/rusefi/wiki/Discord) 🔴
+🔴 Community support ONLY 🔴 [Support Statement](Support) 🔴 [Facebook group](https://www.facebook.com/groups/rusEfi) 🔴 [Discord](Discord) 🔴
 
 [New to rusEFI start here](Home)
 
 [nano Release Software](https://github.com/rusefi/rusefi/releases/latest/download/rusefi_bundle_nano.zip)
 [nano Beta Snapshot](https://rusefi.com/build_server/rusefi_bundle_nano.zip)
-[Release vs Snapshot](https://github.com/rusefi/rusefi/wiki/Release-Snapshot-Latest-firmware)
+[Release vs Snapshot](Release-Snapshot-Latest-firmware)
 
 ## Specs
 

--- a/rusEFI-Huge.md
+++ b/rusEFI-Huge.md
@@ -2,13 +2,13 @@
 
 Our older fully-featured larger ECU available at [💲rusEFI store💲](https://www.shop.rusefi.com/shop/p/rusefi-huge)
 
-🔴 Community support ONLY 🔴 [Support Statement](https://github.com/rusefi/rusefi/wiki/Support) 🔴 [Facebook group](https://www.facebook.com/groups/rusEfi) 🔴 [Discord](https://github.com/rusefi/rusefi/wiki/Discord) 🔴
+🔴 Community support ONLY 🔴 [Support Statement](Support) 🔴 [Facebook group](https://www.facebook.com/groups/rusEfi) 🔴 [Discord](Discord) 🔴
 
 [New to rusEFI start here](Home) [rusEFI-Quick-Start-PDF](rusEFI-Quick-Start-PDF)
 
 [Huge Release Software](https://github.com/rusefi/rusefi/releases/latest/download/rusefi_bundle_alphax-8chan_f7.zip)
 [Huge Beta Snapshot](https://rusefi.com/build_server/rusefi_bundle_alphax-8chan_f7.zip)
-[Release vs Snapshot](https://github.com/rusefi/rusefi/wiki/Release-Snapshot-Latest-firmware)
+[Release vs Snapshot](Release-Snapshot-Latest-firmware)
 
 ## Specs
 
@@ -26,7 +26,7 @@ Our older fully-featured larger ECU available at [💲rusEFI store💲](https://
 * Dual CANbus
 * Dual on-board WBO controller supporting LSU 4.9
 * optional to mount on-board MAP sensor: vertical mpxh6400a, legacy horizontal mpx4250ap
-* optional [JDY-33 bluetooth](https://github.com/rusefi/rusefi/wiki/Bluetooth)
+* optional [JDY-33 bluetooth](Bluetooth)
 
 ## Technical Details
 

--- a/rusEFI-Quick-Start-PDF.md
+++ b/rusEFI-Quick-Start-PDF.md
@@ -70,4 +70,4 @@ https://rusefi.com/s/lua
 
 ## I has a question
 
-See https://github.com/rusefi/rusefi/wiki/Support for this!
+See [Support](Support) for this!

--- a/shop-ru.md
+++ b/shop-ru.md
@@ -6,7 +6,7 @@ Hellen? сложнее, надо писать в [чатик](https://chat.whats
 
 ## Ultra Affordable EFI
 
-https://github.com/rusefi/rusefi/wiki/uaEFI
+[uaEFI](uaEFI)
 
 плата без припаянных молексов стоит столько же, сколько плата с припаяннными молексами - https://www.google.com/search?q=175+usd+to+rub
 
@@ -14,7 +14,7 @@ https://github.com/rusefi/rusefi/wiki/uaEFI
 
 ## mega144
 
-stm32 в форм факторе mega2560 https://github.com/rusefi/rusefi/wiki/mega144
+stm32 в форм факторе mega2560 [mega144](mega144)
 
 https://www.google.com/search?q=49+usd+to+rub
 

--- a/super-uaEFI.md
+++ b/super-uaEFI.md
@@ -2,13 +2,13 @@
 
 A sibling of [uaefi121](uaefi121) with stm32f7 for larger Lua with motorsports superseal headers available at [💲rusEFI store💲](https://www.shop.rusefi.com/shop/p/super-uaefi)
 
-🔴 Community support ONLY 🔴 [Support Statement](https://github.com/rusefi/rusefi/wiki/Support) 🔴 [Facebook group](https://www.facebook.com/groups/rusEfi) 🔴 [Discord](https://github.com/rusefi/rusefi/wiki/Discord) 🔴
+🔴 Community support ONLY 🔴 [Support Statement](Support) 🔴 [Facebook group](https://www.facebook.com/groups/rusEfi) 🔴 [Discord](Discord) 🔴
 
 [New to rusEFI start here](Home)
 
 [super-uaEFI Release Software](https://github.com/rusefi/rusefi/releases/latest/download/rusefi_bundle_super-uaefi.zip)
 [super-uaEFI Beta Snapshot](https://rusefi.com/build_server/rusefi_bundle_super-uaefi.zip)
-[Release vs Snapshot](https://github.com/rusefi/rusefi/wiki/Release-Snapshot-Latest-firmware)
+[Release vs Snapshot](Release-Snapshot-Latest-firmware)
 
 ## Specs
 

--- a/uaEFI-Honda-OBD1.md
+++ b/uaEFI-Honda-OBD1.md
@@ -12,7 +12,7 @@ Sandwich dual PCB adapter board use [uaEFI](uaEFI) firmware
 
 ## Technical Details
 
-See https://github.com/rusefi/rusefi/wiki/uaEFI
+See [uaEFI](uaEFI)
 
 [⏩ Interactive Pinout ⏪](https://rusefi.com/docs/pinouts/uaefi/honda-obd1/)
 
@@ -39,7 +39,7 @@ open source firmware see https://github.com/rusefi/fw-uaefi-Honda-OBD1/issues
 * harness side terminal 0430300001
 * PCB side 2x3 0430450612
 
-See https://github.com/rusefi/rusefi/wiki/Vault-Of-Honda-OEM#obd-1
+See [Vault Of Honda OEM](Vault-Of-Honda-OEM#obd-1)
 
 ## OEM Cases
 

--- a/uaEFI.md
+++ b/uaEFI.md
@@ -2,13 +2,13 @@
 
 Most ECU features in this price category available at [💲rusEFI store💲](https://www.shop.rusefi.com/shop/p/uaefi-ultra-affordable-efi)
 
-🔴 Community support ONLY 🔴 [Support Statement](https://github.com/rusefi/rusefi/wiki/Support) 🔴 [Facebook group](https://www.facebook.com/groups/rusEfi) 🔴 [Discord](https://github.com/rusefi/rusefi/wiki/Discord) 🔴
+🔴 Community support ONLY 🔴 [Support Statement](Support) 🔴 [Facebook group](https://www.facebook.com/groups/rusEfi) 🔴 [Discord](Discord) 🔴
 
 [New to rusEFI start here](Home)
 
 [uaEFI Release Software](https://github.com/rusefi/rusefi/releases/latest/download/rusefi_bundle_uaefi.zip)
 [uaEFI Beta Snapshot](https://rusefi.com/build_server/rusefi_bundle_uaefi.zip)
-[Release vs Snapshot](https://github.com/rusefi/rusefi/wiki/Release-Snapshot-Latest-firmware)
+[Release vs Snapshot](Release-Snapshot-Latest-firmware)
 
 [uaEFI PRO Release Software](https://github.com/rusefi/rusefi/releases/latest/download/rusefi_bundle_uaefi_pro.zip)
 [uaEFI PRO Beta Snapshot](https://rusefi.com/build_server/rusefi_bundle_uaefi_pro.zip)
@@ -44,7 +44,7 @@ Most ECU features in this price category available at [💲rusEFI store💲](htt
 
 ## Technical Details
 
-[General rusEFI documentation](https://github.com/rusefi/rusefi/wiki/Support)
+[General rusEFI documentation](Support)
 
 [Schematics rev c](https://github.com/rusefi/uaefi/raw/main/boards/uaefi-c/board/uaefi-c-schematic.pdf)
 [Schematics rev b](https://github.com/rusefi/uaefi/raw/main/boards/uaefi-b/board/uaefi-b-schematic.pdf)
@@ -54,7 +54,7 @@ Most ECU features in this price category available at [💲rusEFI store💲](htt
 
 [uaEFI interactive BOM rev D](https://rusefi.com/docs/ibom/uaefi-d-ibom.html) [uaEFI interactive BOM rev A](https://rusefi.com/docs/ibom/uaefi-a-ibom.html)
 
-[WBO documentation](https://github.com/rusefi/rusefi/wiki/rusEFI-Wideband-Controller)
+[WBO documentation](rusEFI-Wideband-Controller)
 
 ![x](https://raw.githubusercontent.com/rusefi/uaefi/master/docs/uaefi-a-top.png)
 
@@ -121,7 +121,7 @@ A: definitely would idle v12, not sure if thermal would be a problem at higher R
 
 Q: How do I add bluetooth?
 
-A: See https://github.com/rusefi/rusefi/wiki/Bluetooth#jdy
+A: See [Bluetooth](Bluetooth#jdy)
 
 Q: Where do I buy igniters?
 

--- a/uaefi121.md
+++ b/uaefi121.md
@@ -2,13 +2,13 @@
 
 A sibling of [uaEFI](uaEFI) with metal enclosure available at [💲rusEFI store💲](https://www.shop.rusefi.com/shop/p/uaefi121)
 
-🔴 Community support ONLY 🔴 [Support Statement](https://github.com/rusefi/rusefi/wiki/Support) 🔴 [Facebook group](https://www.facebook.com/groups/rusEfi) 🔴 [Discord](https://github.com/rusefi/rusefi/wiki/Discord) 🔴
+🔴 Community support ONLY 🔴 [Support Statement](Support) 🔴 [Facebook group](https://www.facebook.com/groups/rusEfi) 🔴 [Discord](Discord) 🔴
 
 [New to rusEFI start here](Home)
 
 [uaEFI121 Stable Software](https://github.com/rusefi/rusefi/releases/latest/download/rusefi_bundle_uaefi121.zip)
 [uaEFI121 Beta Snapshot](https://rusefi.com/build_server/rusefi_bundle_uaefi121.zip)
-[Release vs Snapshot](https://github.com/rusefi/rusefi/wiki/Release-Snapshot-Latest-firmware)
+[Release vs Snapshot](Release-Snapshot-Latest-firmware)
 
 ## Specs
 
@@ -50,11 +50,11 @@ A: there are no plans to make this unit open source hardware at the moment. Same
 
 ### Q: I have questions
 
-A: part of the context is fact that uaefi121 is a sibling of fully open source https://github.com/rusefi/uaefi/ so much of https://github.com/rusefi/rusefi/wiki/uaEFI applies
+A: part of the context is fact that uaefi121 is a sibling of fully open source https://github.com/rusefi/uaefi/ so much of [uaEFI](uaEFI) applies
 
 ### Q: which 121 style
 
-A: shipped with 1241434-1 header see also https://github.com/rusefi/rusefi/wiki/OEM-121-pin-connectors
+A: shipped with 1241434-1 header see also [OEM 121 pin connectors](OEM-121-pin-connectors)
 
 ## Changelog
 


### PR DESCRIPTION
These links should work in both Github Wiki and mkdocs, so there's no reason not to use them.