### PR TITLE
Sidebar stuff

### DIFF
--- a/_Sidebar.md
+++ b/_Sidebar.md
@@ -6,7 +6,7 @@
 
 - [How to search the Wiki](HOWTO-Search-on-rusEFI-wiki)
 - [Quick Start](HOWTO-quick-start)
-- [Support](Support)
+- [Support & Community](Support)
 - [How to create a TunerStudio project](HOWTO-create-tunerstudio-project)
 - [rusEFI Online](Online)
 - [HOWTOs and FAQs](Pages-FAQ-and-HOWTO)

--- a/mkdocs/mkdocs.yaml
+++ b/mkdocs/mkdocs.yaml
@@ -27,7 +27,7 @@ nav:
   - 'Downloads': Download.md
   - 'Getting Started':
     - 'Quick Start': HOWTO-quick-start.md
-    - 'Support': Support.md
+    - 'Support & Community': Support.md
     - 'How to create a TunerStudio project': HOWTO-create-tunerstudio-project.md
     - 'rusEFI Online': Online.md
     - 'HOWTOs and FAQs': Pages-FAQ-and-HOWTO.md


### PR DESCRIPTION
- Remove virtual simulator from sidebar
- Sync wiki2 and wiki3 sidebars. This added and removed things from both. One notable loss was the "Community" section from the GH wiki sidebar. See the last commit for a possible approach.
- Rename Hardware sub-categories: "Boards" -> "Wire-in ECUs", "Plug & Play Hardware" -> "Plug & Play ECUs". Is "ECU" the best term here? IMO "Board" is pretty bad. Maybe "Unit"?
- Moved Hellen from Boards/Wire-in ECUs to Plug & Play
- Changed "Support" to "Support & Community"

#585
#588