### PR TITLE
Disable table style lint rule

### DIFF
--- a/wiki-tools/lint.sh
+++ b/wiki-tools/lint.sh
@@ -2,7 +2,7 @@
 STATUS=0
 CHANGED=$(git diff --name-only HEAD~1 HEAD | grep -v '^_' | grep '.md$')
 if [ -n "$CHANGED" ]; then
-  markdownlint -i '_*' -c <(echo '{"default": true,"MD010":{"code_blocks":false}}') --disable MD033 MD034 MD013 MD024 MD036 MD059 -- $CHANGED
+  markdownlint -i '_*' -c <(echo '{"default": true,"MD010":{"code_blocks":false}}') --disable MD033 MD034 MD013 MD024 MD036 MD059 MD060 -- $CHANGED
 fi
 if [ "$?" -gt 0 ]; then
   STATUS=1


### PR DESCRIPTION
Ain't nobody got time for that

IDK why but apparently whatever version is on my machine doesn't have that rule enabled.