### PR TITLE
Get the name of magiclink right

### DIFF
--- a/generator/zensical.toml
+++ b/generator/zensical.toml
@@ -1,5 +1,5 @@
 [project.markdown_extensions.md_in_html]
-[project.markdown_extensions.magiclinks]
+[project.markdown_extensions.pymdownx.magiclink]
 [project.markdown_extensions.toc]
 permalink =  true
 


### PR DESCRIPTION
For some reason, automatic links have just been working in my local env, even without magiclink. Thus I didn't notice the errors. Hopefully this fixes it.