### PR TITLE
docs: fix broken "See also" anchor in Trigger Configuration Guide

### DIFF
--- a/Trigger-Configuration-Guide.md
+++ b/Trigger-Configuration-Guide.md
@@ -72,6 +72,6 @@ The "from" and "to" fields define a range of acceptable ratios for each of the p
 
 Gap is the amount of time that has passed between the current and previous tooth edge detections. The ratio used in this configuration is the ratio between the current gap (i.e. the time between the current and previous tooth edges) and the previous gap (i.e. the time between the previous tooth edge and the tooth edge before that).
 
-See also [Troubleshooting with TS logs](Trigger#troubleshooting-with-ts-logs)
+See also [Troubleshooting with TS logs](Trigger#troubleshooting-with-logs)
 
 See also [How-Do-I-Set-My-Trigger-Offset](How-Do-I-Set-My-Trigger-Offset)


### PR DESCRIPTION
The "Troubleshooting with TS logs" cross-reference linked to Trigger#troubleshooting-with-ts-logs, but the Trigger page has no heading that produces that anchor. Clicking the link therefore landed readers at the top of the Trigger page instead of the relevant section.

Point it at the existing heading "Troubleshooting with logs" (anchor #troubleshooting-with-logs), whose content is specifically about using TS logs to diagnose trigger gaps.