### PR TITLE
docs: cross-link the firmware update and recovery pages

### DIFF
--- a/F7-requires-full-erase.md
+++ b/F7-requires-full-erase.md
@@ -15,3 +15,11 @@ While most rusEFI units support incremental firmware update while keeping settin
 2. In rusEFI console, use "Full Erase Chip"
 
 3. Manual DFU programming using rusEFI console as usual
+
+## Related pages
+
+- [How to Update Firmware](HOWTO-Update-Firmware) - main firmware update procedure (Windows and Linux, OpenBLT and DFU).
+- [HOWTO DFU](HOWTO-DFU) - DFU (Device Firmware Update) mode: auto vs. manual, drivers, and troubleshooting.
+- [HOWTO Flash using STM32CubeProgrammer](HOWTO-flash-using-Stm32CubeProgrammer) - advanced / last-resort flashing via STM32CubeProgrammer (DFU or ST-Link).
+- [Hardware Validation Failed](HARDWARE-VALIDATION-FAILED) - diagnosing the "HARDWARE VALIDATION FAILED" startup error.
+- [4chan F7 Initial Programming](4chan-F7-initial-programming) - one-time initial programming for AlphaX 4chan F7 boards.

--- a/HARDWARE-VALIDATION-FAILED.md
+++ b/HARDWARE-VALIDATION-FAILED.md
@@ -3,3 +3,11 @@
 On startup, after setting pins low, rusEFI firmware checks that the pin is in fact low. If the pin is in fact high, a critical "HARDWARE VALIDATION FAILED" error is raised.
 
 Whatever is the root cause of the issue it's outside of rusEFI firmware control. rusEFI console has useful commands for troubleshooting: `readpin X`, `bench_setpin X`, and `bench_clearpin X`, where `X` is the low level STM32 pin name.
+
+## Related pages
+
+- [How to Update Firmware](HOWTO-Update-Firmware) - main firmware update procedure (Windows and Linux, OpenBLT and DFU).
+- [HOWTO DFU](HOWTO-DFU) - DFU (Device Firmware Update) mode: auto vs. manual, drivers, and troubleshooting.
+- [HOWTO Flash using STM32CubeProgrammer](HOWTO-flash-using-Stm32CubeProgrammer) - advanced / last-resort flashing via STM32CubeProgrammer (DFU or ST-Link).
+- [F7 Requires Full Erase](F7-requires-full-erase) - some F7 Proteus units require a full erase before a firmware update.
+- [4chan F7 Initial Programming](4chan-F7-initial-programming) - one-time initial programming for AlphaX 4chan F7 boards.

--- a/HOWTO-DFU.md
+++ b/HOWTO-DFU.md
@@ -33,3 +33,11 @@ __A:__ Some boards have Tag-Connect-TC2030 upwards three of those! Some boards h
 ### Corrupted option bytes?
 
 A: See https://github.com/rusefi/rusefi/blob/master/firmware/hw_layer/ports/stm32/stm32f4/option-bytes-f407.json https://github.com/rusefi/rusefi/blob/master/firmware/hw_layer/ports/stm32/stm32f4/option-bytes-f427.json https://github.com/rusefi/rusefi/blob/master/firmware/hw_layer/ports/stm32/stm32f7/option-bytes-f767.json reference files, make sure to match your MCU type
+
+## Related pages
+
+- [How to Update Firmware](HOWTO-Update-Firmware) - main firmware update procedure (Windows and Linux, OpenBLT and DFU).
+- [HOWTO Flash using STM32CubeProgrammer](HOWTO-flash-using-Stm32CubeProgrammer) - advanced / last-resort flashing via STM32CubeProgrammer (DFU or ST-Link).
+- [F7 Requires Full Erase](F7-requires-full-erase) - some F7 Proteus units require a full erase before a firmware update.
+- [Hardware Validation Failed](HARDWARE-VALIDATION-FAILED) - diagnosing the "HARDWARE VALIDATION FAILED" startup error.
+- [4chan F7 Initial Programming](4chan-F7-initial-programming) - one-time initial programming for AlphaX 4chan F7 boards.

--- a/HOWTO-Update-Firmware.md
+++ b/HOWTO-Update-Firmware.md
@@ -81,3 +81,11 @@ ST-LINK is an advanced mode of firmware update which requires ST-LINK device, ei
 Once you have updated your firmware, you also need to update your TunerStudio definition so it is able to communicate properly. A happy installation of TunerStudio will download the current .ini file automatically!
 
 If you chose to do it manually, you can find the .ini file in the USB storage device that rusEFI board presents to your computer, or in the [rusEFI bundle](Download).
+
+## Related pages
+
+- [HOWTO DFU](HOWTO-DFU) - DFU (Device Firmware Update) mode: auto vs. manual, drivers, and troubleshooting.
+- [HOWTO Flash using STM32CubeProgrammer](HOWTO-flash-using-Stm32CubeProgrammer) - advanced / last-resort flashing via STM32CubeProgrammer (DFU or ST-Link).
+- [F7 Requires Full Erase](F7-requires-full-erase) - some F7 Proteus units require a full erase before a firmware update.
+- [Hardware Validation Failed](HARDWARE-VALIDATION-FAILED) - diagnosing the "HARDWARE VALIDATION FAILED" startup error.
+- [4chan F7 Initial Programming](4chan-F7-initial-programming) - one-time initial programming for AlphaX 4chan F7 boards.

--- a/HOWTO-flash-using-Stm32CubeProgrammer.md
+++ b/HOWTO-flash-using-Stm32CubeProgrammer.md
@@ -13,3 +13,11 @@ Cube is simple to use.
 A major downside of Stm32CubeProgrammer is some incompatibility between driver versions, which can result in rusEFI Console being unable to update the firmware.
 
 See also [HOWTO-nDBANK](HOWTO-nDBANK)
+
+## Related pages
+
+- [How to Update Firmware](HOWTO-Update-Firmware) - main firmware update procedure (Windows and Linux, OpenBLT and DFU).
+- [HOWTO DFU](HOWTO-DFU) - DFU (Device Firmware Update) mode: auto vs. manual, drivers, and troubleshooting.
+- [F7 Requires Full Erase](F7-requires-full-erase) - some F7 Proteus units require a full erase before a firmware update.
+- [Hardware Validation Failed](HARDWARE-VALIDATION-FAILED) - diagnosing the "HARDWARE VALIDATION FAILED" startup error.
+- [4chan F7 Initial Programming](4chan-F7-initial-programming) - one-time initial programming for AlphaX 4chan F7 boards.


### PR DESCRIPTION
The firmware flashing and recovery pages were largely disconnected: HOWTO-DFU had no internal links to any sibling page, and F7-requires-full-erase, HARDWARE-VALIDATION-FAILED, and 4chan-F7-initial-programming were not reachable from the main update flow. A user recovering a board therefore had to already know the other pages existed.

Add a consistent "Related pages" section to the five core update/recovery pages linking the others, with a one-line description of each. This is an append-only navigation change: no existing content or technical claims are modified. Every link target is an existing page and each description is taken from that page's own content.