### PR TITLE
docs: link the CAN2WiFi adapter from the CAN Bus page

### DIFF
--- a/CAN.md
+++ b/CAN.md
@@ -36,6 +36,8 @@ PCAN
 
 ## Hardware options
 
+[rusEFI CANbus to WiFi adapter](can2wifi) - a first-party wireless bridge for tuning and logging over Wi-Fi (translates TunerStudio TCP to IsoTP over CAN).
+
 [PCAN-USB](https://www.peak-system.com/PCAN-USB.199.0.html?&L=1) with some cable [PCAN-Cable OBD-2](https://www.peak-system.com/PCAN-Cable-OBD-2.273.0.html?&L=1) or [PCAN-Cable 3](https://www.peak-system.com/PCAN-Cable-3.290.0.html?&L=1)
 
 [fake looking like Vasya](https://rusefi.com/forum/viewtopic.php?f=13&t=2243)


### PR DESCRIPTION
The rusEFI CANbus-to-WiFi adapter has its own documentation page (can2wifi) but nothing linked to it, so it was unreachable by browsing the wiki. Add it to the "Hardware options" list on the CAN Bus page, alongside the other CAN adapters, so users can find it.

Append-only: one link added, no existing content changed.