### PR TITLE
docs: cross-link the trigger setup pages

### DIFF
--- a/How-Do-I-Set-My-Trigger-Offset.md
+++ b/How-Do-I-Set-My-Trigger-Offset.md
@@ -31,3 +31,10 @@ To set your trigger offset setting, you must determine how far your ECU is from 
 7. Adjust "Setup" -> "Trigger" -> "Trigger Angle Advance" up or down (negative values are allowed) until you get spark at TDC. This is now your trigger offset.
 8. Reinstall your spark plugs, re-enable fuel, set your timing to something sensible, (manufacturer recommendations) and try to start your engine. Verify the timing again with a timing light once the engine runs, and adjust the offset if needed.
 9. Change your timing mode back to "dynamic" or you will continue to run on fixed timing and give up a ton of power and fuel economy and have some *really* high exhaust temperatures.
+
+## Related pages
+
+- [Triggers](Trigger) - trigger overview: how rusEFI reads crank/cam position, plus troubleshooting.
+- [Trigger Configuration Guide](Trigger-Configuration-Guide) - configuring Hall/VR sensors, sensor polarity, and gap overrides.
+- [All Supported Triggers](All-Supported-Triggers) - list of built-in trigger patterns with diagrams.
+- [Unknown Trigger](Unknown-Trigger) - what to do when your trigger pattern is not yet supported.

--- a/Trigger-Configuration-Guide.md
+++ b/Trigger-Configuration-Guide.md
@@ -75,3 +75,10 @@ Gap is the amount of time that has passed between the current and previous tooth
 See also [Troubleshooting with TS logs](Trigger#troubleshooting-with-logs)
 
 See also [How-Do-I-Set-My-Trigger-Offset](How-Do-I-Set-My-Trigger-Offset)
+
+## Related pages
+
+- [Triggers](Trigger) - trigger overview: how rusEFI reads crank/cam position, plus troubleshooting.
+- [All Supported Triggers](All-Supported-Triggers) - list of built-in trigger patterns with diagrams.
+- [Setting Trigger Offset](How-Do-I-Set-My-Trigger-Offset) - setting the global trigger angle offset.
+- [Unknown Trigger](Unknown-Trigger) - what to do when your trigger pattern is not yet supported.

--- a/Trigger.md
+++ b/Trigger.md
@@ -8,6 +8,8 @@ See also [Setting Trigger Offset](How-Do-I-Set-My-Trigger-Offset)
 
 See [Trigger Hardware](Trigger-Hardware) for some notes on the difference between Hall and VR sensors.
 
+See [Unknown Trigger](Unknown-Trigger) for what to do when your trigger pattern is not yet supported.
+
 ## Troubleshooting Trigger Input
 
 We use engine sniffer and composite logger only for basic validation at the moment. Please use regular TS logs with a higher data rate if adjustments to trigger gaps are needed. The logs collected with "Data Logging" -> "Start Logging" are the only kind worth sharing.

--- a/Unknown-Trigger.md
+++ b/Unknown-Trigger.md
@@ -45,3 +45,10 @@ Next you need to find a unique gap in the events to use as the synchronization p
 Trigger synchronization often does not happen right at TDC. One would need to find out the angle between the synchronization point and the Top Dead Center of cylinder #1.
 
 See [Setting Trigger Offset](How-Do-I-Set-My-Trigger-Offset)
+
+## Related pages
+
+- [Triggers](Trigger) - trigger overview: how rusEFI reads crank/cam position, plus troubleshooting.
+- [Trigger Configuration Guide](Trigger-Configuration-Guide) - configuring Hall/VR sensors, sensor polarity, and gap overrides.
+- [All Supported Triggers](All-Supported-Triggers) - list of built-in trigger patterns with diagrams.
+- [Setting Trigger Offset](How-Do-I-Set-My-Trigger-Offset) - setting the global trigger angle offset.


### PR DESCRIPTION
The trigger pages were only loosely connected: Unknown-Trigger was not linked from anywhere, and the Trigger Configuration Guide and Setting Trigger Offset pages did not link back to the Triggers overview or to the list of supported triggers.

Add a consistent "Related pages" section to the hand-maintained trigger pages, and link Unknown-Trigger from the Triggers overview. Append-only: no existing content or technical claims changed. All-Supported-Triggers (a generated page) is linked but not edited.