### PR TITLE
docs: add a Communications index page

### DIFF
--- a/Pages-Communications.md
+++ b/Pages-Communications.md
@@ -1,0 +1,25 @@
+# Master list of communications pages
+
+<details markdown="1" class="abstract"><summary><u>CAN bus</u></summary>
+
+* [CAN Bus overview](CAN)
+* [TunerStudio over CAN](TS-over-CAN)
+* [Calibration via CAN](rusEFI-calibration-via-CAN)
+* [Firmware update via CAN](Firmware-update-via-CAN)
+* [CANbus to WiFi adapter](can2wifi)
+
+</details>
+
+<details markdown="1" class="abstract"><summary><u>Serial and Bluetooth</u></summary>
+
+* [Serial](Serial)
+* [Bluetooth](Bluetooth)
+
+</details>
+
+<details markdown="1" class="abstract"><summary><u>External devices and integration</u></summary>
+
+* [Communicate with a transmission controller (TCU)](HOWTO-Make-Your-Own-ECU-Communicate-with-TCU)
+* [E65 CAN bus (BMW example)](E65-CAN-bus)
+
+</details>

--- a/_Sidebar.md
+++ b/_Sidebar.md
@@ -54,6 +54,7 @@
 - [Sensors and Actuators](Pages-Sensors-and-Actuators)
 - [Ignition](Pages-Ignition)
 - [Software](Pages-Software)
+- [Communications](Pages-Communications)
 - [Info Vaults](Pages-Info-Vaults)
 
 ## Contributors


### PR DESCRIPTION
The wiki has "master list" index pages for Fuel, Sensors and Actuators, Ignition, Software, and Info Vaults, but none for communications, even though there are many CAN, serial, and Bluetooth pages. They were only reachable by direct linking or search.

Add Pages-Communications, matching the existing Pages-* index format, grouping the CAN, serial/Bluetooth, and external-device pages, and add it to the sidebar Index list.

Navigation only: every entry links an existing page; no content changed.