### PR TITLE
docs: cross-link the electronic throttle (ETB) pages

### DIFF
--- a/Electronic-Throttle-Body-Configuration-Guide.md
+++ b/Electronic-Throttle-Body-Configuration-Guide.md
@@ -113,3 +113,9 @@ If the blade does not ever move, it's time to grab a multimeter and confirm the 
 ### Does the TPS sensor function?
 
 Moving the blade manually, do you see both raw TPS values change reasonably?
+
+## Related pages
+
+- [Electronic Throttle Body](Electronic-Throttle-Body) - overview of electronic throttle (drive-by-wire) control.
+- [Vault of Electronic Throttle Bodies](Vault-Of-Electronic-Throttle-Bodies-ETB) - list of tested throttle bodies and their details.
+- [SENT Electronic Throttle Body](SENT-ETB-Electronic-Throttle-Body) - throttle bodies that use the SENT protocol.

--- a/Electronic-Throttle-Body.md
+++ b/Electronic-Throttle-Body.md
@@ -30,3 +30,9 @@ rusEFI hardware and software have been designed to work with all three of these 
 - DC motor driver H-bridge(s) to control the motor. An H-bridge can apply a variable voltage using PWM in either direction. Both directions are important to be able to open and close the throttle completely.
 - Analog inputs and corresponding software to measure both the TPS and PPS.
 - A control algorithm that uses a table to linearize the effects of the return spring and PID to move the throttle to the targeted position.
+
+## Related pages
+
+- [Electronic Throttle Body Configuration Guide](Electronic-Throttle-Body-Configuration-Guide) - step-by-step electronic throttle body setup and tuning.
+- [Vault of Electronic Throttle Bodies](Vault-Of-Electronic-Throttle-Bodies-ETB) - list of tested throttle bodies and their details.
+- [SENT Electronic Throttle Body](SENT-ETB-Electronic-Throttle-Body) - throttle bodies that use the SENT protocol.

--- a/SENT-ETB-Electronic-Throttle-Body.md
+++ b/SENT-ETB-Electronic-Throttle-Body.md
@@ -38,3 +38,9 @@ kit <https://www.bmotorsports.com/shop/product_info.php/products_id/4479>
 At the moment uaEFI, Huge and microRusEFI have SENT capable pins.
 
 See https://github.com/rusefi/rusefi/tree/master/firmware/hw_layer/drivers/sent
+
+## Related pages
+
+- [Electronic Throttle Body](Electronic-Throttle-Body) - overview of electronic throttle (drive-by-wire) control.
+- [Electronic Throttle Body Configuration Guide](Electronic-Throttle-Body-Configuration-Guide) - step-by-step electronic throttle body setup and tuning.
+- [Vault of Electronic Throttle Bodies](Vault-Of-Electronic-Throttle-Bodies-ETB) - list of tested throttle bodies and their details.

--- a/Vault-Of-Electronic-Throttle-Bodies-ETB.md
+++ b/Vault-Of-Electronic-Throttle-Bodies-ETB.md
@@ -119,3 +119,9 @@ There are many W163 (Mercedes ML SUV) in the junkyards so even used these sensor
 lots of useful information [here](https://www.maxxecu.com/webhelp/wirings-e-throttle_bodies.html)
 
 ![image](Images/diagrams/ETB_module_wiring.png)
+
+## Related pages
+
+- [Electronic Throttle Body](Electronic-Throttle-Body) - overview of electronic throttle (drive-by-wire) control.
+- [Electronic Throttle Body Configuration Guide](Electronic-Throttle-Body-Configuration-Guide) - step-by-step electronic throttle body setup and tuning.
+- [SENT Electronic Throttle Body](SENT-ETB-Electronic-Throttle-Body) - throttle bodies that use the SENT protocol.


### PR DESCRIPTION
The four electronic-throttle pages did not fully link each other. In particular the Electronic Throttle Body Configuration Guide - the main setup page - had no links to the ETB overview, the vault of tested throttle bodies, or the SENT ETB page.

Add a consistent "Related pages" section to each of the four ETB pages linking the others. Append-only navigation: no existing content or technical claims changed; every link target is an existing page.