### PR TITLE
docs: add Idle Control and Launch Control to the sidebar

### DIFF
--- a/_Sidebar.md
+++ b/_Sidebar.md
@@ -18,6 +18,7 @@
 - [Trigger - Configuration](Trigger-Configuration-Guide)
 - [Trigger - Setting Offset](How-Do-I-Set-My-Trigger-Offset)
 - [Electronic Throttle](Electronic-Throttle-Body)
+- [Idle Control](Idle-Control)
 - [Logging](Logging-Guide)
 - [Wideband Oxygen Sensors](Wide-Band-Sensors)
 - [Fueling](Fuel-Overview)
@@ -28,6 +29,7 @@
 - [Lua Scripting](Lua-Scripting)
 - [Digital Dash](Digital-Dash)
 - [Multispark](Multi-Spark)
+- [Launch Control](HOWTO-Launch-Control)
 
 ## ECU Hardware
 


### PR DESCRIPTION
The Idle Control and Launch Control pages were not listed in the sidebar, even though their peer engine-management guides (VVT, Flex Fuel, Multispark, Knock Sensing, etc.) are. This made them hard to find.

Add both to the sidebar Guides list next to the other feature guides. Navigation only: both link to existing pages; no content changed.