### PR TITLE
docs: surface the Medium Band Oxygen Sensor page

### DIFF
--- a/Pages-Sensors-and-Actuators.md
+++ b/Pages-Sensors-and-Actuators.md
@@ -24,6 +24,7 @@
 <details markdown="1" class="abstract"><summary><u>AFR measurement (Wideband)</u></summary>
 
 * [Wide Band Sensors](Wide-Band-Sensors)
+* [Medium Band Oxygen Sensor](Medium-band-oxygen)
 
 </details>
 

--- a/Wide-Band-Sensors.md
+++ b/Wide-Band-Sensors.md
@@ -94,3 +94,8 @@ connector body is laser trimmed with this value."
 1j0973733 Bosch 4.2 6 pin connector available everywhere
 
 [ALM-CAN lambda meter](http://www.ecotrons.com/products/wideband-controller-alm-can/)
+
+## Related pages
+
+- [rusEFI Wideband Controller](rusEFI-Wideband-Controller) - the open-source rusEFI wideband controller.
+- [Medium Band Oxygen Sensor](Medium-band-oxygen) - Denso two-wire (medium-band) oxygen sensor wiring and pinout.


### PR DESCRIPTION
The Medium Band Oxygen Sensor page (Denso two-wire sensor wiring and pinout) was not linked from anywhere, so it was unreachable by browsing.

Link it from the Wideband Oxygen Sensors page (new "Related pages" section) and add it to the "AFR measurement" group of the Sensors and Actuators index. Navigation only; both link to existing pages.