### PR TITLE
docs: add an Injection Modes page

### DIFF
--- a/Home.md
+++ b/Home.md
@@ -27,8 +27,8 @@ In order to use rusEFI you will need to acquire one of the [supported control un
 | [Hall, VR, CLT, TPS and all popular sensors](FAQ-Basic-Wiring-and-Connections)                              | ✓          |
 | [20+ OEM Triggers Supported](All-Supported-Triggers)                                                        | ✓          |
 | [TunerStudio online tuning](HOWTO-create-tunerstudio-project)                                               | ✓          |
-| [Batch Injection](https://rusefi.com/docs/guide/#menu_Fuel_Injection_configuration)                         | ✓          |
-| [Sequential Injection up to 12 cylinders](https://rusefi.com/docs/guide/#menu_Fuel_Injection_configuration) | ✓          |
+| [Batch Injection](Injection-Modes#batch)                                                                    | ✓          |
+| [Sequential Injection up to 12 cylinders](Injection-Modes#sequential)                                       | ✓          |
 | [Staged Injection](Staged-Injection)                                                                        | ✓          |
 | [Direct Injection](GDI-status)                                                                              | ✓          |
 | [Flex Fuel](Flex-Fuel) 🌽                                                                                   | ✓          |

--- a/Injection-Modes.md
+++ b/Injection-Modes.md
@@ -1,0 +1,40 @@
+# Injection Modes
+
+rusEFI can fire the fuel injectors in several different ways, selected by the `injectionMode` setting. This controls how the ECU groups and times the injector outputs. Choose the mode that matches your injectors and what your trigger setup can support.
+
+## Available modes
+
+The `injectionMode` setting offers these options (labels as shown in TunerStudio):
+
+### Simultaneous
+
+All injectors open at the same time. This is the simplest arrangement and does not require the ECU to know which cylinder is on its intake stroke.
+
+### Batch
+
+Injectors fire in groups (banks) rather than individually, typically delivering fuel more than once per engine cycle. Batch injection does not require a camshaft (phase) signal, which makes it a common choice when only a crankshaft signal is available.
+
+### Sequential
+
+Each injector is fired individually, timed to its own cylinder's cycle. Sequential injection needs **camshaft synchronization** so the firmware knows each cylinder's position in the four-stroke cycle. This is the mode to use for fully sequential fuelling.
+
+### Single Point
+
+A single injector (or a small number of injectors) mounted at a central location, such as a throttle body, feeds all cylinders — the arrangement used by throttle-body injection (TBI) systems.
+
+## Choosing a mode
+
+- Match the mode to your injectors and manifold. Sequential requires one injector per cylinder and a cam signal; batch and simultaneous can run from a crank signal alone.
+- Wire each injector output according to your board's pinout — see the [injector wiring section](FAQ-Basic-Wiring-and-Connections#fuel-injectors).
+- To add a second set of injectors that stage in at higher demand, see [Staged Injection](Staged-Injection).
+- After setup, verify fuelling on a live [log](Logging-Guide) across the RPM and load range.
+
+## Related pages
+
+- [Fuel Overview](Fuel-Overview) — how rusEFI calculates fuel.
+- [Staged Injection](Staged-Injection) — using primary plus secondary injector sets.
+- [Wiring & Connectivity Overview](FAQ-Basic-Wiring-and-Connections) — injector wiring.
+
+## Technical sources
+
+- Configuration field definitions: `firmware/integration/rusefi_config.txt` (`injectionMode`, enum `injection_mode_e`).

--- a/Pages-Fuel.md
+++ b/Pages-Fuel.md
@@ -3,6 +3,7 @@
 <details markdown="1" class="abstract"><summary><u>Fuel Algorithms</u></summary>
 
 * [Fuel Overview](Fuel-Overview)
+* [Injection Modes](Injection-Modes)
 * [Cranking](Cranking)
 * [AlphaN](AlphaN)
 * [Speed Density](Speed-Density)


### PR DESCRIPTION
The Home feature table listed "Batch Injection" and "Sequential Injection" but both linked to the external TunerStudio guide - there was no wiki page describing rusEFI's fuel injection modes.

Add an Injection Modes page describing the injectionMode options (Simultaneous, Batch, Sequential, Single Point), with wiring pointers and a link to staged injection. Option labels come from firmware (integration/rusefi_config.txt, injection_mode_e). Point the two Home injection links at the new page and add it to the Fuel index.