### PR TITLE
docs: document VVT closed-loop control on the VVT page

### DIFF
--- a/VVT.md
+++ b/VVT.md
@@ -34,3 +34,20 @@ For example, 3/1 skipped wheel with cam sensor in the first half of the 720 cycl
 ![VVT Config](Images/TS/VVT_config.png)
 
 Full list see [All Supported Triggers](All-Supported-Triggers)
+
+## VVT control
+
+Beyond decoding cam position, rusEFI can actively **control** variable cam timing in closed loop: it compares the measured cam angle against a target and drives the cam phaser to reach it.
+
+- **Feedback:** the camshaft sensor (`camInputs`) provides the actual cam position. `vvtOffsets` sets the "Angle between cam sensor and VVT zero position", which calibrates the measured cam angle so that the target is meaningful.
+- **Target:** separate **VVT intake target** and **VVT exhaust target** tables set the desired cam angle across the operating range.
+- **Actuation:** a PID controller drives a PWM output to the cam (oil) control solenoid to move the cam toward the target.
+- **Enable conditions:** VVT control only runs above `vvtControlMinRpm`. Cam phasers depend on engine oil pressure and temperature, so control is not expected to work at cold start or very low RPM.
+
+> ⚠️ **Set VVT limits conservatively.** On interference engines, commanding the cam too far can cause valve-to-piston contact and serious engine damage. Confirm the achievable cam range carefully and verify behaviour on a [log](Logging-Guide) before relying on VVT control.
+
+Configure the VVT targets, PID gains, control pins, and limits in TunerStudio; no values are prescribed here.
+
+## Technical sources
+
+- Configuration field definitions: `firmware/integration/rusefi_config.txt` — `vvtControlMinRpm`, `camInputs`, `vvtOffsets`, the VVT intake/exhaust target tables, and the VVT PID.


### PR DESCRIPTION
The VVT page covered cam trigger decoding but never explained VVT control - how rusEFI drives the cam phaser to a target. Add a "VVT control" section: closed-loop PID drives a cam control solenoid toward a target from the VVT intake/exhaust target tables, using cam feedback (camInputs) calibrated by vvtOffsets, gated by vvtControlMinRpm. Includes an interference-engine safety caution. Field names are from firmware (integration/rusefi_config.txt); no numeric values are prescribed. Existing content is unchanged (append-only).