### PR TITLE
docs: add an Anti-Lag (ALS) page

### DIFF
--- a/Antilag.md
+++ b/Antilag.md
@@ -1,0 +1,32 @@
+# Anti-Lag (ALS)
+
+> ⚠️ **DANGER — competition-only feature. Read this before enabling.**
+>
+> Anti-lag deliberately keeps combustion energy high in the exhaust so the turbocharger stays spooled while you are off the throttle. This produces **very high exhaust and turbocharger temperatures**, heavy mechanical and thermal stress, and loud backfires. It can shorten the life of, or destroy, the **turbocharger, exhaust, valves, and catalytic converter**, and it is not emissions-legal.
+>
+> It is intended for **closed-course competition use only**, on engines and turbochargers specifically built and prepared for it. Do not use it on the street or on hardware that is not prepared for it. Introduce it gradually, **monitor exhaust gas temperature (EGT)** continuously, and verify behaviour on a [log](Logging-Guide). Use at your own risk.
+
+Anti-lag (also called ALS, anti-lag system) reduces turbo lag by keeping the turbocharger spinning while the engine is off the throttle, so that boost returns almost immediately when you get back on it.
+
+## Activation
+
+The overall feature is turned on with `antiLagEnabled`. When and how it runs is set by `antiLagActivationMode`, which offers three options:
+
+- **Switch Input** — activated by a driver-operated switch wired to the `ALSActivatePin` input.
+- **Always Active** — runs whenever its configured conditions are met.
+- **Lua** — activated from a [Lua script](Lua-Scripting), for custom activation logic.
+
+## Tuning
+
+The timing, fuelling, and the RPM and throttle conditions that anti-lag uses are configured in TunerStudio. Set them conservatively, watch EGT closely, and confirm the behaviour on a [log](Logging-Guide) before relying on it.
+
+## Related pages
+
+- [Launch Control](HOWTO-Launch-Control) — often used together with anti-lag.
+- [Boost Control](Boost-Control)
+- [Lua Scripting](Lua-Scripting) — one of the anti-lag activation modes.
+- [Logging Guide](Logging-Guide)
+
+## Technical sources
+
+- Configuration field definitions: `firmware/integration/rusefi_config.txt` — `antiLagEnabled`, `antiLagActivationMode` (Switch Input / Always Active / Lua), `ALSActivatePin`.

--- a/Home.md
+++ b/Home.md
@@ -47,7 +47,7 @@ In order to use rusEFI you will need to acquire one of the [supported control un
 | [Boost Control](Boost-Control)                                                                              | ✓          |
 | [Launch Control](HOWTO-Launch-Control)                                                                      | ✓          |
 | [Flat Shifting](https://rusefi.com/docs/guide/#menu_Advanced_Shift_Torque_Reduction_(Flat_Shift))           | ✓          |
-| [Antilag](https://github.com/rusefi/rusefi/issues/2403)                                                     | ✓          |
+| [Antilag](Antilag)                                                                                          | ✓          |
 | [Boost-by-gear](https://github.com/rusefi/rusefi/issues/2404)                                               | ✓          |
 | [Traction Control](https://rusefi.com/docs/guide/#menu_Controller_Traction_Control_ETB_drop)                | ✓          |
 | [Blending (advanced version of dual table)](Blending)                                                       | ✓          |


### PR DESCRIPTION
Anti-lag was listed as a supported feature on the Home page but linked to a GitHub issue - there was no wiki page. Add an Anti-Lag page that leads with a strong competition-only / EGT / hardware-damage disclaimer, then documents the verified activation configuration: antiLagEnabled and antiLagActivationMode (Switch Input / Always Active / Lua) with the ALSActivatePin input. Field names are from firmware (integration/rusefi_config.txt). The exact timing/fuel tuning is deferred to TunerStudio; no numeric values are prescribed. Point the Home feature link at the new page. (Not added to the sidebar, given the hazard.)