### PR TITLE
docs: add a Diagnostics and Logging hub page

### DIFF
--- a/Diagnostics-and-Logging.md
+++ b/Diagnostics-and-Logging.md
@@ -1,0 +1,32 @@
+# Diagnostics and Logging
+
+This page collects the tools rusEFI gives you to see what the ECU is doing and to capture data for tuning or for asking the community for help. If you are chasing a specific symptom, start from [Troubleshooting](Troubleshooting) instead — this page is organised by tool rather than by problem.
+
+> When you ask for help, a **proper log file** is almost always the first thing you will be asked for. Screenshots and videos are not enough. See the [Logging Guide](Logging-Guide).
+
+## Live data
+
+- [rusEFI Console](Console) — monitor live data and send diagnostic commands to the ECU.
+- [TunerStudio Connectivity](Tunerstudio-Connectivity) — connect TunerStudio and read its gauges.
+
+## Logs
+
+- [Logging Guide](Logging-Guide) — how to record the correct type of log file.
+- [How to Upload a Log](HOWTO-upload-log) — sharing a log with the community.
+
+## Trigger diagnostics
+
+- [Triggers — Troubleshooting Trigger Input](Trigger#troubleshooting-trigger-input) — using the engine sniffer, composite logger, and tooth logger to diagnose trigger and synchronization problems.
+
+## Status indicators and codes
+
+- [LED states](LED-states) — what the board LEDs mean.
+- [rusEFI Error Codes](Error-Codes) — OBD codes, cut codes, and ETB error codes.
+
+## Testing without an engine
+
+- [rusEFI Virtual Simulator](Virtual-simulator) — exercise the firmware and console on a PC without any hardware.
+
+## See also
+
+- [Troubleshooting](Troubleshooting) — a symptom-based starting point for common problems.

--- a/_Sidebar.md
+++ b/_Sidebar.md
@@ -21,6 +21,7 @@
 - [Trigger - Setting Offset](How-Do-I-Set-My-Trigger-Offset)
 - [Electronic Throttle](Electronic-Throttle-Body)
 - [Idle Control](Idle-Control)
+- [Diagnostics & Logging](Diagnostics-and-Logging)
 - [Logging](Logging-Guide)
 - [Wideband Oxygen Sensors](Wide-Band-Sensors)
 - [Fueling](Fuel-Overview)


### PR DESCRIPTION
The tools for seeing what the ECU is doing and capturing data - the console, TunerStudio, logs, trigger sniffers, LED states, error codes, and the simulator - were scattered across separate pages. Add a Diagnostics and Logging page that gathers them, organised by tool, and add it to the sidebar. It complements the symptom-based Troubleshooting page and cross-links to it. Navigation/orientation only: every link points to an existing page and every section deep-link was verified.