### PR TITLE
docs: surface the Injector Lag Tuning page

### DIFF
--- a/Fuel-Overview.md
+++ b/Fuel-Overview.md
@@ -22,7 +22,7 @@ Wideband Oxygen Sensor is pretty much a requirement for both manual and auto-tun
 
 ![General Settings](Images/Fuel_Control/general.png)
 
-Within each fuel calculation mode, there is coolant temperature correction ("warm-up mode"), battery voltage correction and injector open time ("injector lag") correction.
+Within each fuel calculation mode, there is coolant temperature correction ("warm-up mode"), battery voltage correction and injector open time ("injector lag") correction. See [Injector Lag Tuning](Injector-Lag-Autotune) for how to check and correct injector lag.
 
 Commands related to injector lag:
 

--- a/Pages-Fuel.md
+++ b/Pages-Fuel.md
@@ -28,6 +28,7 @@
 * [Converting from Carb](how-to-convert-from-carburetor-to-EFI)
 * [GDI Status](GDI-status)
 * [Staged Injection](Staged-Injection)
+* [Injector Lag Tuning](Injector-Lag-Autotune)
 * [Basic Injector Wiring](FAQ-Basic-Wiring-and-Connections#fuel-injectors)
 
 </details>


### PR DESCRIPTION
The Injector Lag Tuning page was not linked from anywhere, so it was unreachable by browsing. Link it from the Fuel Overview page (right where injector lag correction is described) and add it to the Fuel index. Navigation only; the target is an existing page.