### PR TITLE
docs: link crimping and connector pages from the wiring overview

### DIFF
--- a/FAQ-Basic-Wiring-and-Connections.md
+++ b/FAQ-Basic-Wiring-and-Connections.md
@@ -147,3 +147,10 @@ In regards to Knock Sensor quality of signal, a shielded cable (2 core) is recom
 - Shield and GND of sensor goe to Sensor GND
 
 Doing it this way is preferred to get the best performance from your ECU input and sensor.
+
+## Related pages
+
+- [Crimping Hints](HOWTO-Crimp) - general crimping tips.
+- [Crimping Ampseal Connectors](HOWTO-Crimp-Ampseal) - crimping the Ampseal connectors used on many rusEFI boards.
+- [OEM Connectors](OEM-connectors) - reference of OEM connector pinouts and part numbers.
+- [TE/AMP Superseal](TE-AMP-Superseal) - notes on TE/AMP Superseal connectors.


### PR DESCRIPTION
The Wiring & Connectivity Overview did not link to the crimping or connector reference pages, and Crimping Hints and TE/AMP Superseal were not reachable from anywhere. Add a "Related pages" section to the wiring overview linking the crimping and connector pages. Append-only navigation; every target is an existing page.