### PR TITLE
docs: cross-link the custom-board development pages

### DIFF
--- a/Custom-Firmware.md
+++ b/Custom-Firmware.md
@@ -81,3 +81,9 @@ A: stm32 has a limitation: you can only have 16 digital inputs. Also each input 
 ### Q: How do I have nice pin names?
 
 A: see https://github.com/rusefi/fw-custom-example/blob/main/connectors/readme.md
+
+## Related pages
+
+- [How to Make a Plug-and-Play Board](HOWTO-Make-a-PnP-board) - designing a plug-and-play board for a specific vehicle.
+- [How to Test a New ECU Design](HOWTO-Test-New-ECU-Design) - bringing up and testing a newly built board.
+- [Developer Quick Start](Dev-Quick-Start) - setting up the rusEFI development environment.

--- a/HOWTO-Make-a-PnP-board.md
+++ b/HOWTO-Make-a-PnP-board.md
@@ -66,3 +66,9 @@ Steps:
 16. Final step: go back and update your spreadsheet with what you ACTUALLY connected. Make sure your OEM coil numbers are mapped to the coil driver that is connected on the PCB. Make sure the OEM injector numbers are mapped to the drivers controlling them. Make sure that the specific sensors on the harness are mapped to the general analog inputs receiving the signal. Make sure your solenoids, relays, etc. are mapped to GPIO. When you go to configure the unit, having this information to refer to will be invaluable and save you having to chase your schematic.
 
 See also [How To Test a New ECU Design](HOWTO-Test-New-ECU-Design)
+
+## Related pages
+
+- [Custom rusEFI Firmware](Custom-Firmware) - building firmware for a custom board.
+- [How to Test a New ECU Design](HOWTO-Test-New-ECU-Design) - bringing up and testing a newly built board.
+- [Developer Quick Start](Dev-Quick-Start) - setting up the rusEFI development environment.

--- a/HOWTO-Test-New-ECU-Design.md
+++ b/HOWTO-Test-New-ECU-Design.md
@@ -32,3 +32,9 @@ If dealing with a brand-new, never before tested hardware design it's recommende
 5. Test & Report, with USB physically disconnected: Attempt cranking. If equipped with on-board persistent storage, upload & link log to report.
 6. Connect ECU to laptop via serial, report type of serial.
 7. With laptop connected via serial, test & report, with USB physically disconnected: ECU status LED blinks if powered up, ECU status LED blinks when ignition powered off.
+
+## Related pages
+
+- [How to Make a Plug-and-Play Board](HOWTO-Make-a-PnP-board) - designing a plug-and-play board for a specific vehicle.
+- [Custom rusEFI Firmware](Custom-Firmware) - building firmware for a custom board.
+- [Developer Quick Start](Dev-Quick-Start) - setting up the rusEFI development environment.


### PR DESCRIPTION
The pages for designing your own rusEFI hardware were poorly connected: the substantial "How to Make a Plug-and-Play Board" guide was not linked from anywhere, and the custom firmware and new-ECU-testing pages did not reference each other. Add a "Related pages" section to each linking the others plus the Developer Quick Start. Append-only navigation; every target is an existing page.