### PR TITLE
docs: add algorithm selection and cross-links to MAF

### DIFF
--- a/MAF.md
+++ b/MAF.md
@@ -68,3 +68,13 @@ If a different air/fuel ratio is desired at a specific load or RPM, then the AFR
 ![VE Table](Images/TS/TunerStudio_VE_table.png)
 
 Some useful MAF sensor maths in [this link](https://www.efunda.com/designstandards/sensors/hot_wires/hot_wires_theory.cfm)
+
+## Related pages
+
+- [Speed Density](Speed-Density) — the MAP-based algorithm, rusEFI's primary recommendation.
+- [AlphaN](AlphaN) — the throttle-position based algorithm.
+- [Fuel Overview](Fuel-Overview) — how rusEFI calculates fuel.
+
+## Technical sources
+
+- Configuration field definitions: `firmware/integration/rusefi_config.txt` — `fuelAlgorithm` (`engine_load_mode_e`: Speed Density / Alpha-N / MAF Air Charge / Lua). Select "MAF Air Charge" to use this strategy.


### PR DESCRIPTION
Round out the fuel-algorithm pages: the MAF page now links Speed Density, AlphaN, and Fuel Overview, and notes that MAF is selected by setting the fuel algorithm (fuelAlgorithm) to "MAF Air Charge". Field labels are from firmware (integration/rusefi_config.txt). Existing content, including the experimental-status warning, is unchanged (append-only).