### PR TITLE
docs: link the fuel algorithm pages from Fuel Overview

### DIFF
--- a/Fuel-Overview.md
+++ b/Fuel-Overview.md
@@ -12,11 +12,11 @@ rusEFI supports mono, individual/sequential and batched fuel injection using one
 
 1. MAF-based or MAP-based table fuel lookup with interpolation - these algorithms only use the raw sensor output and thus they do not account for ambient air temperature; this is only intended as a minimum viable hardware configuration and we would suggest using the AlphaN, Speed Density or MAF air charge methods instead.
 
-2. TPS-based table fuel lookup with interpolation (AlphaN)
+2. TPS-based table fuel lookup with interpolation ([AlphaN](AlphaN))
 
-3. MAP-based Speed Density model, with fuel auto-tune provided by a fully registered copy of TunerStudio
+3. MAP-based [Speed Density](Speed-Density) model, with fuel auto-tune provided by a fully registered copy of TunerStudio
 
-4. MAF-based air charge model that computes the air mass in the cylinder and thus the required fuel quantity from the direct measurement of the mass air flow.
+4. [MAF](MAF)-based air charge model that computes the air mass in the cylinder and thus the required fuel quantity from the direct measurement of the mass air flow.
 
 Wideband Oxygen Sensor is pretty much a requirement for both manual and auto-tuning.
 


### PR DESCRIPTION
The Fuel Overview listed AlphaN, Speed Density, and MAF air charge as plain text. Link each to its page so the algorithm pages are reachable from the main fuel page (they already link back). Only the three algorithm names are turned into links; no other content changed.