### PR TITLE
docs: add a Sensors and Calibration hub

### DIFF
--- a/Sensors-and-Calibration.md
+++ b/Sensors-and-Calibration.md
@@ -1,0 +1,33 @@
+# Sensors and Calibration
+
+Every rusEFI tune depends on the sensors reading correctly — the firmware can only be as accurate as the data it is given. This page is the starting point for setting up and calibrating the sensors on your engine.
+
+For sensor wiring specifics, see the [Wiring & Connectivity Overview](FAQ-Basic-Wiring-and-Connections). For a list of tested sensors and their known values, see the [Vault of Sensors](Vault-Of-Sensors).
+
+## Temperature
+
+- [Coolant and Intake Air Temperature (CLT/IAT)](Temperature-Sensors) — thermistor bias resistor and three-point calibration.
+
+## Pressure
+
+- [MAP Sensor](MAP-Sensor) — manifold absolute pressure; sensor presets and two-point calibration.
+- [Oil Pressure (and linear analog sensors)](Oil-Pressure-Sensor) — two-point voltage-to-pressure calibration, also used for fuel pressure and other linear sensors.
+
+## Throttle
+
+- [Throttle Position and Pedal (TPS/APP)](Throttle-and-Pedal-Sensors) — closed / wide-open calibration and drive-by-wire pedal redundancy.
+
+## Air/fuel ratio (oxygen)
+
+- [Wideband Oxygen Sensors](Wide-Band-Sensors) — wideband / lambda AFR measurement.
+- [Medium Band Oxygen Sensor](Medium-band-oxygen) — Denso two-wire sensor.
+
+## Position and combustion
+
+- [Triggers](Trigger) — crank and cam position sensors and trigger setup.
+- [Knock Sensing](knock-sensing) — detonation detection and response.
+
+## See also
+
+- [Vault of Sensors](Vault-Of-Sensors) — tested sensors and known calibration values.
+- [Sensors and Actuators index](Pages-Sensors-and-Actuators) — the full list.

--- a/_Sidebar.md
+++ b/_Sidebar.md
@@ -21,6 +21,7 @@
 - [Trigger - Setting Offset](How-Do-I-Set-My-Trigger-Offset)
 - [Electronic Throttle](Electronic-Throttle-Body)
 - [Idle Control](Idle-Control)
+- [Sensors & Calibration](Sensors-and-Calibration)
 - [Diagnostics & Logging](Diagnostics-and-Logging)
 - [Logging](Logging-Guide)
 - [Wideband Oxygen Sensors](Wide-Band-Sensors)


### PR DESCRIPTION
Give the sensor documentation a front door. Add a Sensors and Calibration page that gathers the sensor setup/calibration pages by category (temperature, pressure, throttle/pedal, oxygen, position and combustion) and links the wiring overview and the Vault of Sensors, and add it to the sidebar Guides. Navigation/orientation only; every link points to an existing wiki page.