### PR TITLE
docs: document stepper idle valve wiring/drive modes

### DIFF
--- a/Idle-Control.md
+++ b/Idle-Control.md
@@ -20,6 +20,15 @@ For example, here we have 10% extra opening at 30C.
 
 In the case of a stepper valve, in order to get to a known position we retract the valve all the way at startup and then go to the desired position. A solenoid-based valve does not require any initialization.
 
+## Stepper idle valve wiring
+
+Set `useStepperIdle` when you have a stepper-motor idle valve (bipolar, usually 4-wire). rusEFI can drive a stepper in two ways:
+
+- **Step / direction driver** — a dedicated stepper driver IC (on the board, or added via a drop-in adapter) is controlled by `stepperStepPin` and `stepperDirectionPin`. rusEFI sends step and direction signals, and the driver powers the motor coils. This is the usual method.
+- **Direct coil drive** — set `useRawOutputToDriveIdleStepper`, described in the firmware as: "If enabled we use four Push-Pull outputs to directly drive stepper idle air valve coils". This drives the two coils directly from four suitable outputs (for example the H-bridges on Proteus) instead of using a step/direction driver.
+
+Unipolar stepper valves are not supported. See the [Wiring & Connectivity Overview](FAQ-Basic-Wiring-and-Connections#idle-air-control-valve) for more on the idle valve types.
+
 ## Closed-loop idle control
 
 The `idleMode` setting chooses between two strategies:
@@ -37,4 +46,4 @@ Configure the target idle RPM, the PID gains, and these thresholds in TunerStudi
 
 ## Technical sources
 
-- Configuration field definitions: `firmware/integration/rusefi_config.txt` — `idleMode`, `idleRpmPid`, `idlePidDeactivationTpsThreshold`, `idlePidRpmUpperLimit`, `idlePidRpmDeadZone`, and the `idle` hardware settings (`solenoidFrequency`, `solenoidPin`, `useStepperIdle`).
+- Configuration field definitions: `firmware/integration/rusefi_config.txt` — `idleMode`, `idleRpmPid`, `idlePidDeactivationTpsThreshold`, `idlePidRpmUpperLimit`, `idlePidRpmDeadZone`, and the `idle` hardware settings (`solenoidFrequency`, `solenoidPin`, `useStepperIdle`, `stepperStepPin`, `stepperDirectionPin`, `useRawOutputToDriveIdleStepper`).


### PR DESCRIPTION
The Idle Control page noted a stepper valve needs an add-on board but did not explain how rusEFI drives one. Add a "Stepper idle valve wiring" section covering the two drive modes: a step/direction driver (stepperStepPin, stepperDirectionPin) and direct four-output coil drive (useRawOutputToDriveIdleStepper), enabled by useStepperIdle, with a note that unipolar steppers are unsupported. Extend the Technical Sources accordingly. Field names/comments are from firmware (integration/rusefi_config.txt); no values prescribed.