### PR TITLE
docs: add a Tachometer Output page

### DIFF
--- a/Pages-Sensors-and-Actuators.md
+++ b/Pages-Sensors-and-Actuators.md
@@ -60,6 +60,12 @@
 
 </details>
 
+<details markdown="1" class="abstract"><summary><u>Tachometer Output</u></summary>
+
+* [Tachometer Output](Tachometer-Output)
+
+</details>
+
 <details markdown="1" class="abstract"><summary><u>Fuel Injectors</u></summary>
 
 * [GDI Status](GDI-status)

--- a/Tachometer-Output.md
+++ b/Tachometer-Output.md
@@ -1,0 +1,25 @@
+# Tachometer Output
+
+rusEFI can drive a dashboard tachometer (rev counter) by sending a pulse signal that represents engine speed, so a factory or aftermarket analog tach can display RPM from rusEFI.
+
+## Configuration
+
+- `tachOutputPin` (with `tachOutputPinMode`) — the output that sends the tach signal.
+- `tachPulsePerRev` — the number of pulses sent per engine revolution. Set this to what your gauge expects (it usually relates to the cylinder count the gauge was designed for).
+- `tachPulseDuractionMs` — the pulse duration, described in the firmware as "Duration in ms or duty cycle depending on selected mode".
+- `tachPulseDurationAsDutyCycle` — chooses whether that value is a "Constant time" (a fixed number of milliseconds) or a "Duty cycle" ("Treat milliseconds value as duty cycle value, i.e. 0.5ms would become 50%").
+
+## Setting it up
+
+1. Wire the tach output to the gauge's signal input — see the [Wiring & Connectivity Overview](FAQ-Basic-Wiring-and-Connections).
+2. Select the tach output pin in TunerStudio.
+3. Set `tachPulsePerRev` to match the gauge, then compare the gauge reading to the rusEFI RPM value and adjust pulses-per-rev until they agree.
+4. If the gauge reads erratically or sticks, adjust the pulse duration or switch between constant-time and duty-cycle mode.
+
+## Related pages
+
+- [Wiring & Connectivity Overview](FAQ-Basic-Wiring-and-Connections) — outputs and wiring.
+
+## Technical sources
+
+- Configuration field definitions: `firmware/integration/rusefi_config.txt` — `tachOutputPin`, `tachOutputPinMode`, `tachPulsePerRev`, `tachPulseDuractionMs`, `tachPulseDurationAsDutyCycle`.


### PR DESCRIPTION
Continue the output documentation. Add a Tachometer Output page: driving a dashboard tach with a pulse signal, the tachOutputPin, pulses per revolution (tachPulsePerRev), and the pulse duration / constant-time vs duty-cycle mode. Add a Tachometer Output group to the Sensors and Actuators index. Field names/comments are from firmware (integration/rusefi_config.txt); no values prescribed.