### PR TITLE
docs: improve discoverability of Nitrous and Bluetooth pages

### DIFF
--- a/Boost-Control.md
+++ b/Boost-Control.md
@@ -50,6 +50,7 @@ The main boost-control configuration items are listed below by their configurati
 - [Wiring & Connectivity Overview](FAQ-Basic-Wiring-and-Connections) — output types and solenoid wiring.
 - [Logging Guide](Logging-Guide) — essential for tuning and verifying boost safely.
 - [Lua Scripting](Lua-Scripting) — the `setBoostTargetAdd` and `setBoostTargetMult` functions can adjust the boost target from a script.
+- [Nitrous](Nitrous) — another power-adder; rusEFI has no built-in nitrous controller, but it can be implemented with Lua scripting alongside boost.
 - [Smart ECU (proposed overboost protection)](Vault-Smart-ECU) — proposed/future protection concepts, not current behaviour.
 
 ## Technical sources

--- a/Pages-Fuel.md
+++ b/Pages-Fuel.md
@@ -34,3 +34,10 @@
 * [Basic Injector Wiring](FAQ-Basic-Wiring-and-Connections#fuel-injectors)
 
 </details>
+
+<details markdown="1" class="abstract"><summary><u>Power Adders</u></summary>
+
+* [Boost Control](Boost-Control)
+* [Nitrous](Nitrous)
+
+</details>

--- a/_Sidebar.md
+++ b/_Sidebar.md
@@ -32,6 +32,7 @@
 - [Variable Valve Timing](VVT)
 - [Lua Scripting](Lua-Scripting)
 - [Digital Dash](Digital-Dash)
+- [Bluetooth](Bluetooth)
 - [Multispark](Multi-Spark)
 - [Launch Control](HOWTO-Launch-Control)
 - [Boost Control](Boost-Control)


### PR DESCRIPTION
Nitrous had no inbound links at all - it was unreachable by browsing. Surface it from the Fuel index (new "Power Adders" group alongside Boost Control) and cross-link it from the Boost Control page, since both are power-adder topics.

Bluetooth was linked from Home and the Communications index but not from the sidebar, making it a click further away than similar topics like Digital Dash. Add it to the sidebar Guides list next to Digital Dash.

Navigation only: no existing content changed, all targets verified.