### PR TITLE
docs: group the sidebar Guides section by topic and complete the Sens…

### DIFF
--- a/Sensors-and-Calibration.md
+++ b/Sensors-and-Calibration.md
@@ -12,6 +12,7 @@ For sensor wiring specifics, see the [Wiring & Connectivity Overview](FAQ-Basic-
 
 - [MAP Sensor](MAP-Sensor) — manifold absolute pressure; sensor presets and two-point calibration.
 - [Oil Pressure (and linear analog sensors)](Oil-Pressure-Sensor) — two-point voltage-to-pressure calibration, also used for fuel pressure and other linear sensors.
+- [Fuel Pressure](Fuel-Pressure) — low-side and high-pressure (GDI) fuel sensors, and why fuel pressure matters for injector flow.
 
 ## Throttle
 
@@ -26,6 +27,18 @@ For sensor wiring specifics, see the [Wiring & Connectivity Overview](FAQ-Basic-
 
 - [Triggers](Trigger) — crank and cam position sensors and trigger setup.
 - [Knock Sensing](knock-sensing) — detonation detection and response.
+
+## Vehicle speed
+
+- [Vehicle Speed Sensor (VSS)](Vehicle-Speed-Sensor) — road speed input, also used for wheel-slip features like traction control.
+
+## Related actuators and outputs
+
+These are not sensors, but they use the sensor data above and are commonly set up alongside it:
+
+- [Cooling Fan Control](Cooling-Fan-Control) — fan switching based on coolant temperature.
+- [Air Conditioning (A/C) Control](Air-Conditioning-Control) — compressor control and idle-up.
+- [Tachometer Output](Tachometer-Output) — driving a dashboard tach from engine speed.
 
 ## See also
 

--- a/_Sidebar.md
+++ b/_Sidebar.md
@@ -14,28 +14,53 @@
 
 ## Guides
 
+### Troubleshooting & Diagnostics
+
 - [Troubleshooting](Troubleshooting)
-- [Wiring & Connectivity Overview](FAQ-Basic-Wiring-and-Connections)
-- [Cranking](Cranking)
-- [Trigger - Configuration](Trigger-Configuration-Guide)
-- [Trigger - Setting Offset](How-Do-I-Set-My-Trigger-Offset)
-- [Electronic Throttle](Electronic-Throttle-Body)
-- [Idle Control](Idle-Control)
-- [Sensors & Calibration](Sensors-and-Calibration)
 - [Diagnostics & Logging](Diagnostics-and-Logging)
 - [Logging](Logging-Guide)
+
+### Wiring, Sensors & Calibration
+
+- [Wiring & Connectivity Overview](FAQ-Basic-Wiring-and-Connections)
+- [Sensors & Calibration](Sensors-and-Calibration)
 - [Wideband Oxygen Sensors](Wide-Band-Sensors)
+
+### Trigger & Idle
+
+- [Trigger - Configuration](Trigger-Configuration-Guide)
+- [Trigger - Setting Offset](How-Do-I-Set-My-Trigger-Offset)
+- [Cranking](Cranking)
+- [Idle Control](Idle-Control)
+
+### Fuel
+
 - [Fueling](Fuel-Overview)
 - [Flex Fuel](Flex-Fuel)
 - [Direct Injection](GDI-status)
+
+### Ignition
+
 - [Knock Sensing](knock-sensing)
-- [Variable Valve Timing](VVT)
-- [Lua Scripting](Lua-Scripting)
-- [Digital Dash](Digital-Dash)
 - [Multispark](Multi-Spark)
+
+### Electronic Throttle
+
+- [Electronic Throttle](Electronic-Throttle-Body)
+
+### Advanced & Performance
+
+- [Variable Valve Timing](VVT)
 - [Launch Control](HOWTO-Launch-Control)
+- [Flat Shifting](Flat-Shifting)
 - [Boost Control](Boost-Control)
 - [Traction Control](Traction-Control)
+
+### Dash & Connectivity
+
+- [Lua Scripting](Lua-Scripting)
+- [Digital Dash](Digital-Dash)
+- [Bluetooth](Bluetooth)
 
 ## ECU Hardware
 


### PR DESCRIPTION
…ors hub

The sidebar's "Guides" section had grown into a flat, unsorted list of 23+ links, making it hard to scan or predict where a topic would be. Group it into topic sub-sections (matching the pattern already used under "ECU Hardware"): Troubleshooting & Diagnostics, Wiring/Sensors & Calibration, Trigger & Idle, Fuel, Ignition, Electronic Throttle, Advanced & Performance, and Dash & Connectivity. Every existing link is preserved, only reorganised; Bluetooth and Flat Shifting are added to their groups (Flat Shifting was previously missing from the sidebar entirely, unlike its sibling features).

Also complete the Sensors and Calibration hub, which had not been kept up to date as more sensor/actuator pages were added after it was created: add Fuel Pressure, Vehicle Speed Sensor, and a new "Related actuators and outputs" section for Cooling Fan Control, A/C Control, and Tachometer Output.

Navigation only; every link target verified to exist.