### PR TITLE
docs: fix stale board links in the sidebar

### DIFF
--- a/_Sidebar.md
+++ b/_Sidebar.md
@@ -45,14 +45,14 @@
 
 - [uaEFI](uaEFI)
 - [microRusEFI](microRusEFI-Manual)
-- [Proteus](Proteus)
+- [Proteus](Proteus-Manual)
 
 ### Plug-and-Play ECUs
 
 - [Honda OBD1](uaEFI-Honda-OBD1)
 - [GM E38](GM-E38)
 - [GM E92](PnP-E92)
-- [Hellen](https://github.com/rusefi/rusefi/wiki/Hellen-One-Platform)
+- [Hellen](Hellen-One-Platform)
 
 - [Other Hardware](Other-Hardware)
 


### PR DESCRIPTION
The sidebar's "Proteus" link pointed to Proteus.md, which is explicitly marked "OLD PAGE" and redirects readers to Proteus-Manual - point the sidebar at the current page instead.

The "Hellen" link pointed to the external generated wiki mirror (github.com/rusefi/rusefi/wiki/Hellen-One-Platform) instead of this repo's own Hellen-One-Platform.md page, which already exists and is a substantial hub. Point it at the local page, consistent with every other sidebar entry.

Navigation only; both new targets verified to exist.