### PR TITLE
docs: surface the orphaned combo10 page from Digital Dash

### DIFF
--- a/Digital-Dash.md
+++ b/Digital-Dash.md
@@ -6,9 +6,10 @@ See also: [Dash-hardware-comparison](Dash-hardware-comparison)
 
 The dash situation is not ideal. Open question what is acceptable boot time and what is boot time for each of the options.
 
-We have four versions of Digital Dash currently.
+We have five versions of Digital Dash currently.
 
 1. [TunerStudio running on a Raspberry Pi](Digital-Dash-TunerStudio)
 2. [PowerTune running on a Raspberry Pi 3](https://rusefi.com/forum/viewtopic.php?p=41535)
 3. A custom digital gauge cluster such as [uaDash](uaDASH) or [PiDGC](https://github.com/joshellissh/pidgc) ([Example on Josh's blog](https://mycustomcars.us/custom-digital-gauge-cluster/))
 4. An Android tablet or phone running an app such as [Real Dash](http://realdash.net/index.php), [Shadow Dash](Shadow-Dash), or [MSDroid](MSDroid)
+5. [combo10](combo10), a 10-inch touchscreen dashboard with a customizable gauge layout, an initial engine-configuration wizard, and limited on-device tuning. A Windows Dash Simulator is available to try the interface without hardware.


### PR DESCRIPTION
combo10 is a rusEFI 10-inch touchscreen dashboard with a complete, well-written wiki page, but nothing in the wiki links to it -- it is reachable only by knowing the URL. Digital Dash is the page that enumerates the dash options, so add combo10 there as a fifth option and update the count to match.

Link only, no new technical claims: the description is taken from the combo10 page itself.