### PR TITLE
docs: restructure the uaEFI page to production quality

### DIFF
--- a/uaEFI.md
+++ b/uaEFI.md
@@ -12,41 +12,114 @@ The most fully-featured ECU in this price category; available at [💲rusEFI Sto
 [🆕rusEFI_Universal_Updater with Beta Snapshot🆕](https://rusefi.com/installer/rusEFI_Universal_Updater.exe)
 [ℹ️Release vs Snapshotℹ️](Release-Snapshot-Latest-firmware)
 
+![uaEFI board, top view](Images/uaefi-a-top.png)
 
 ## Specs
 
 * [⏩ Interactive Pinout ⏪](https://rusefi.com/docs/pinouts/hellen/uaefi/)
 * One of the eight [universal units we offer](Hardware)
+
+### Ignition and injection
+
 * Sequential six smart coils with option of on-board igniters
 * Sequential six injector outputs for more complex engines
 * Capable of driving 8 sequential injector outputs on simpler engines
-* Four above 1A current low side outputs (six on new revisions)
-* A couple of lower current low side outputs
+
+### Inputs
+
 * Two VRs: one MAX9924 one vr-discrete (Add R1 to switch MAX9924 into Hall mode)
 * Three hall inputs
-* Two DC motor drivers up to 6A. Can drive two ETBs or ETB + electronic wastegate or stepper idle
-* On-board 4.9 LSU WBO controller
+* 9+2 analog inputs
+* [Flex fuel](Flex-Fuel) input
+* [Knock sensor](knock-sensing) input
+* On-board digital baro sensor
+
+### Outputs
+
+* Four above 1A current low side outputs (six on new revisions)
+* A couple of lower current low side outputs
+* Two DC motor drivers up to 6A. Can drive two [ETBs](Electronic-Throttle-Body-Configuration-Guide) or ETB + electronic wastegate or [stepper idle](Idle-Control#stepper-idle-valve-wiring)
+
+### On-board
+
+* On-board 4.9 LSU [WBO controller](rusEFI-Wideband-Controller)
 * On-board SD card
 * Up to two CAN buses
-* On-board digital baro sensor
-* 9+2 analog inputs
-* Flex fuel input
-* Knock sensor input
-* Proto area
-* 100x100mm 4 layer PCB
-* Expandable with on-board IGBT igniters (many parts would work, we like ISL9V3040D3ST)
-* Expandable with on-board MAP sensor (MPX4250AP or smaller MPXH6400AC)
-* Expandable with on-board Bluetooth (JDY-33 would need to be soldered)
-* Expandable with on-board EGT input (MAX31855 and related passives would need to be soldered)
-* Expandable with second CAN bus (TJA1051T and related passives would need to be soldered)
 * On-board real time cr1220 clock battery (software broken https://github.com/rusefi/rusefi/issues/4556)
-* PRO comes with extra memory for Lua and more powerful stm32f7 MCU
-* PRO comes with second CAN bus populated
-* free open source firmware - support us at https://www.patreon.com/rusefi
+
+### Physical
+
+* 100x100mm 4 layer PCB
+* Proto area
+
+free open source firmware - support us at https://www.patreon.com/rusefi
+
+## uaEFI vs uaEFI PRO
+
+94% of users should go with Normal. The PRO variant adds:
+
+| PRO adds | Detail |
+|---|---|
+| More powerful MCU | stm32f7 |
+| Extra memory for Lua | Much more complex Lua scripts |
+| Second CAN bus populated | On the base board this is an expansion option, see below |
+| Knock spectrogram feature | |
+
+Each variant has its own firmware bundle — see the download links at the top of this page.
+
+## Expansion options
+
+The base board is designed to be extended. Each of these needs parts soldered on:
+
+| Expansion | What is needed |
+|---|---|
+| On-board IGBT igniters (to drive dumb coils) | Many parts would work, we like ISL9V3040D3ST |
+| On-board MAP sensor | MPX4250AP or smaller MPXH6400AC |
+| On-board [Bluetooth](Bluetooth#supported-modules) | JDY-33 would need to be soldered |
+| On-board EGT input | MAX31855 and related passives would need to be soldered |
+| Second CAN bus | TJA1051T and related passives would need to be soldered |
+
+See notes on the schematics: they have part numbers to add and reference numbers to remove.
+
+## uaEFI User Documentation
+
+New to rusEFI? Start with the [Getting Started roadmap](Getting-Started), which walks through the whole path from choosing hardware to a first start.
+
+| Topic | Page |
+|---|---|
+| Wiring and connections | [Wiring & Connectivity Overview](FAQ-Basic-Wiring-and-Connections) |
+| Firmware install and updates | [HOWTO Update Firmware](HOWTO-Update-Firmware), [Release vs Snapshot](Release-Snapshot-Latest-firmware) |
+| Trigger setup | [Trigger Configuration Guide](Trigger-Configuration-Guide) |
+| On-board wideband | [rusEFI Wideband Controller](rusEFI-Wideband-Controller) |
+| Idle control | [Idle Control](Idle-Control), [Stepper Motor](Stepper-Motor) |
+| Electronic throttle | [Electronic Throttle Body Configuration Guide](Electronic-Throttle-Body-Configuration-Guide) |
+| Wireless connection | [Bluetooth](Bluetooth) |
+| Logging and diagnostics | [Diagnostics and Logging](Diagnostics-and-Logging) |
+| Something is wrong | [Troubleshooting](Troubleshooting) |
+
+## Connectors
+
+Harness plugs are Molex Mini Fit Jr. Circuit counts are encoded in the part numbers.
+
+| Connector | Circuits | Harness plug (Molex Mini Fit Jr) | PCB header |
+|---|---|---|---|
+| A | 8 | 39012080 or 39012085 | 5569-08A2, 39300080, 39301080 |
+| B | 18 | 39012180 or 39012185 | 5569-18A2, 39301180 |
+| C | 20 | 39012200 or 39012205 | 5569-20A2, 39301200 |
+| D | 16 | 39012160 or 39012165 | 5569-16A2, 39301160 |
+| E | 6 | 39012060 or 39012065 | 5569-06A2, 39301060 |
+
+### External USB connector
+
+USBBF7
+
+### WBO connector
+
+![WBO Connector Wires](Images/uaEFI_WBO_wires.png){: style="width: 232px; height: 126px;" }
+
+![uaEFI wideband wiring diagram](Images/diagrams/uaEFI_wideband.png)
 
 ## Technical Details
-
-[Support & Community](Support)
 
 [Schematics and fab files](https://github.com/rusefi/uaefi/tree/main/boards)
 
@@ -54,48 +127,31 @@ The most fully-featured ECU in this price category; available at [💲rusEFI Sto
 
 [uaEFI interactive BOM rev D](https://rusefi.com/docs/ibom/uaefi-d-ibom.html) [uaEFI interactive BOM rev A](https://rusefi.com/docs/ibom/uaefi-a-ibom.html)
 
-[WBO documentation](rusEFI-Wideband-Controller)
+[Support & Community](Support)
 
-![x](Images/uaefi-a-top.png)
-
-![x](Images/uaefi_a_bottom.png)
-
-## Harness Connectors
-
-Molex Mini Fit Jr
-
-* A 39012080 or 39012085
-* B 39012180 or 39012185
-* C 39012200 or 39012205
-* D 39012160 or 39012165
-* E 39012060 or 39012065
-
-## PCB headers
-
-* A 5569-08A2 39300080 39301080
-* B 5569-18A2 39301180
-* C 5569-20A2 39301200
-* D 5569-16A2 39301160
-* E 5569-06A2 39301060
-
-## External USB connector
-
-USBBF7
-
-## WBO Connector
-
-![WBO Connector Wires](Images/uaEFI_WBO_wires.png){: style="width: 232px; height: 126px;" }
-
-![wideband_for_dummies](Images/diagrams/uaEFI_wideband.png)
+![uaEFI board, bottom view](Images/uaefi_a_bottom.png)
 
 ## Adapters
 
 Want to make an adapter? See https://github.com/rusefi/uaefi-NA6-adapter
 
+There is also a dedicated variant for Honda OBD1: [Ultra Affordable EFI for Honda OBD1](uaEFI-Honda-OBD1).
+
 ## FAQ
+
+### Buying
 
 *__Q:__ How do I order from Europe?*  
 __A:__ https://shop.rusefi.com is the only official store, there are no distributors for this ultra affordable unit.
+
+*__Q:__ What's the difference between normal and PRO?*  
+__A:__ 94% of users should go with Normal. PRO can do much more complex Lua scripts, PRO also has a knock spectrogram feature. See [uaEFI vs uaEFI PRO](#uaefi-vs-uaefi-pro) above.
+
+*__Q:__ Do you have any dealer prices or discount for companies?*  
+__A:__ There is too little profit margin on these to offer discounts, sorry.
+PCB files are available for free; you should be able to order your own. Paid consulting is available on how to set things up with JLCPCB if you need help.
+
+### Engine compatibility
 
 *__Q:__ Can it do 8x8?*  
 __A:__ You would have to remove two flyback diodes to have 8 similar injector outputs. You would have to figure out a way to have 8 equal coil outputs, maybe settle on wasted spark?
@@ -105,23 +161,18 @@ Additional notes at https://rusefi.com/docs/pinouts/hellen/uaefi/?connector=b&pi
 __A:__ Consider replacing chips with VNLD5090.
 
 *__Q:__ Can it do a v12?*  
-__A:__ It's not recommended. This board was designed for one injector per channel, so a v12 means two injectors per channel. It definitely would idle a v12; it's not certain whether thermals would be a problem at higher RPM. [Proteus](Proteus) or [rusEFI Huge](rusEFI-Huge) is recommended for a v12.
+__A:__ It's not recommended. uaEFI has six injector drivers and this board was designed for one injector per driver. A v12 has twelve injectors, so you would have to wire two injectors to each driver. That is no longer sequential injection, and each driver then has to carry the current of two injectors instead of one — which is why thermals are the concern. It definitely would idle a v12; whether the drivers get too hot at higher RPM is not certain. [Proteus](Proteus) or [rusEFI Huge](rusEFI-Huge) is recommended for a v12.
 
-*__Q:__ What's the difference between normal and PRO?*  
-__A:__ 94% of users should go with Normal. PRO can do much more complex Lua scripts, PRO also has a knock spectrogram feature.
-
-*__Q:__ Do you have any dealer prices or discount for companies?*  
-__A:__ There is too little profit margin on these to offer discounts, sorry.
-PCB files are available for free; you should be able to order your own. Paid consulting is available on how to set things up with JLCPCB if you need help.
+### Hardware and features
 
 *__Q:__ How do I use uaEFI with dumb coils?*  
 __A:__ See notes on the schematics, it has part numbers to add and reference numbers to remove!
 
-*__Q:__ How do I add Bluetooth?*  
-__A:__ A JDY-33 module needs to be soldered on — see [Bluetooth](Bluetooth#supported-modules).
-
 *__Q:__ Where do I buy igniters?*  
 __A:__ See https://www.findchips.com/search/ISL9V3040D for stock at distributors.
+
+*__Q:__ How do I add Bluetooth?*  
+__A:__ A JDY-33 module needs to be soldered on — see [Bluetooth](Bluetooth#supported-modules).
 
 *__Q:__ Can it control a stepper motor?*  
 __A:__ Yes, it's possible — uaEFI drives a 4-wire stepper from its two DC motor drivers. See [Stepper Motor](Stepper-Motor) and [Stepper idle valve wiring](Idle-Control#stepper-idle-valve-wiring). There are two ways to set it up in TunerStudio:
@@ -133,6 +184,13 @@ __A:__ Yes, it's possible — uaEFI drives a 4-wire stepper from its two DC moto
 *Older detailed way:*
 
 ![TunerStudio stepper idle settings](Images/TS/TunerStudio_idle_stepper.png)
+
+## Related pages
+
+* [Hardware](Hardware) — all eight universal units
+* [uaEFI 121](uaefi121) — sibling with a metal enclosure and automotive header
+* [super-uaEFI](super-uaEFI) — sibling with STM32F7 and superseal headers
+* [Ultra Affordable EFI for Honda OBD1](uaEFI-Honda-OBD1) — Honda OBD1 variant
 
 🔴 [Commercial Support](https://www.shop.rusefi.com/shop/p/details-about-rusefi-ecu-technical-support) 🔴
 

--- a/uaEFI.md
+++ b/uaEFI.md
@@ -99,15 +99,22 @@ New to rusEFI? Start with the [Getting Started roadmap](Getting-Started), which 
 
 ## Connectors
 
-Harness plugs are Molex Mini Fit Jr. Circuit counts are encoded in the part numbers.
+All five harness connectors are **Molex [Mini-Fit Jr.](https://www.molex.com/en-us/products/connectors/wire-to-board-connectors/mini-fit-connectors)**, a 4.20 mm pitch dual-row power connector family. The harness side uses **5557-series receptacle housings** and the board side uses **5569-series right-angle headers**, so a single Mini-Fit Jr. crimp terminal and one crimp tool cover the whole harness. Circuit counts are encoded in the part numbers.
 
-| Connector | Circuits | Harness plug (Molex Mini Fit Jr) | PCB header |
+| Connector | Circuits | Harness plug (Molex 5557 receptacle housing) | PCB header (Molex 5569 right-angle header) |
 |---|---|---|---|
-| A | 8 | 39012080 or 39012085 | 5569-08A2, 39300080, 39301080 |
-| B | 18 | 39012180 or 39012185 | 5569-18A2, 39301180 |
-| C | 20 | 39012200 or 39012205 | 5569-20A2, 39301200 |
-| D | 16 | 39012160 or 39012165 | 5569-16A2, 39301160 |
-| E | 6 | 39012060 or 39012065 | 5569-06A2, 39301060 |
+| A | 8 | 39012080 or 39012085 | 39301080 (legacy 5569-08A2), 39300080 |
+| B | 18 | 39012180 or 39012185 | 39301180 (legacy 5569-18A2) |
+| C | 20 | 39012200 or 39012205 | 39301200 (legacy 5569-20A2) |
+| D | 16 | 39012160 or 39012165 | 39301160 (legacy 5569-16A2) |
+| E | 6 | 39012060 or 39012065 | 39301060 (legacy 5569-06A2) |
+
+Two things that make the list above look more confusing than it is:
+
+- **The pairs are the same housing in two flame ratings.** The part ending in `0` is UL 94V-2 and the one ending in `5` is UL 94V-0 — for example 39012080 and 39012085 are both 8-circuit Mini-Fit Jr. receptacle housings. Either one mates; 94V-0 is the more flame-retardant material.
+- **`5569-xxA2` is Molex's legacy numbering** for the same right-angle headers, so 5569-08A2 and 39301080 are one part, not two.
+
+You also need Mini-Fit Jr. **crimp terminals** and a matching crimp tool; these are not part-specific to uaEFI and are listed on the Mini-Fit Jr. family page linked above.
 
 ### External USB connector
 


### PR DESCRIPTION
**Builds on #716 — please merge that one first.** Until it does, this PR's diff shows both commits.

uaEFI is one of the most important boards in the project and its page had grown into a flat wall of bullets. This restructures it along the same shape `microRusEFI-Manual` already uses — hero image, Specs, a User Documentation section, then FAQ — and moves repeated data into tables, which are already used widely across this wiki.

**No specification, part number or hardware claim is changed.** Every part number and fact from the previous revision is still present; I verified this mechanically against the old file.

- Board photo moved to the top, matching microRusEFI and uaEFI 121.
- The 30-item Specs list grouped into Ignition and injection / Inputs / Outputs / On-board / Physical. Item wording unchanged.
- New **uaEFI vs uaEFI PRO** table — the PRO bullets were buried mid-spec-list and the rest of the answer was only in the FAQ, so the purchasing decision was split across the page.
- New **Expansion options** table.
- New **Connectors** table merging the old "Harness Connectors" and "PCB headers" lists — connectors A–E were previously listed twice and had to be cross-referenced by hand. **Worth a spot check:** the Circuits column is derived from the part numbers themselves, since both families encode it consistently (`39-01-2080` and `5569-08A2` are both 8 circuit).
- New **uaEFI User Documentation** section, the one `microRusEFI-Manual` has and this page didn't. Routes to wiring, firmware, trigger, wideband, idle, ETB and troubleshooting.
- New **Related pages** footer. uaEFI 121 already linked here, but this page linked to none of its siblings or the Honda OBD1 variant.
- FAQ grouped under Buying / Engine compatibility / Hardware and features. Q&A text is unchanged apart from the v12 answer, so most of that part of the diff is movement rather than rewriting.
- The v12 answer now explains the mechanism: six injector drivers, twelve injectors, so two share each driver — no longer sequential, and double the current per driver, which is what the thermal caveat was about.

The house header block, the Commercial Support footer and the video link are untouched. All links, anchors and images on the page were verified against master.
