### PR TITLE
docs: fix broken links, typos, and complete the ignition index

### DIFF
--- a/Dev-Console-Implementation.md
+++ b/Dev-Console-Implementation.md
@@ -28,4 +28,4 @@ The transport layer pushes data into EngineState.processNewData() which splits t
 
 Outgoing data flow:
 
-CommandQueue is the class which takes care of sending commands, making sure a confirmation is recieved and re-trying outgoing data transfer if needed.
+CommandQueue is the class which takes care of sending commands, making sure a confirmation is received and re-trying outgoing data transfer if needed.

--- a/Mazda-Miata-1999.md
+++ b/Mazda-Miata-1999.md
@@ -4,7 +4,7 @@
 
 [Mazda MX5 1.8 1999 AE](http://rusefi.com/forum/viewtopic.php?f=3&t=467)
 
-[Mazda Miata NB1 Trigger](All-Supported-Triggers#mazda-miata-nb)
+[Mazda Miata NB1 Trigger](All-Supported-Triggers#mazda_miata_nb1)
 
 `set engine_type 9`
 

--- a/Multi-Spark.md
+++ b/Multi-Spark.md
@@ -46,7 +46,7 @@ This is the delay between sparks during multispark.
 
 ### Dwell(ms)
 
-This is the ignition dwell used for subsequent sparks. Keep in mind that this does not need to be as long as your main ignition dwell due to a partial burn having already occured. Nor *should* it be as long in order to prevent overheating of the ignition coils.  
+This is the ignition dwell used for subsequent sparks. Keep in mind that this does not need to be as long as your main ignition dwell due to a partial burn having already occurred. Nor *should* it be as long in order to prevent overheating of the ignition coils.  
 
 ## Example
 

--- a/Pages-Ignition.md
+++ b/Pages-Ignition.md
@@ -1,7 +1,10 @@
 # Master list of Ignition pages
   
 - **[Ignition FAQ](FAQ-Ignition)**
+- [Ignition](Ignition)
 - [Ignition Modes](Ignition-Modes)
+- [Multispark Ignition](Multi-Spark)
+- [Knock Sensing](knock-sensing)
 - [Rev Limiter (RPM Limit)](Rev-Limiter)
 - [Basic Ignition Wiring](FAQ-Basic-Wiring-and-Connections#coils)
 - [List of tested coils, ignition modules, and IGBTs](Vault-Of-Ignition-Parts)

--- a/X-tau-Wall-Wetting.md
+++ b/X-tau-Wall-Wetting.md
@@ -64,7 +64,7 @@ Good tuning of the X-tau system relies on taking logs and some trial and error t
 
 ## Old Info
 
-![config](X-tau-Wall-Wetting)
+![config](Overview/wall_wetting/wall_wetting_sample_config.jpg)
 
 ![log](Overview/wall_wetting/wall_wetting_log.jpg)
 

--- a/jackm_carhack_nissan.md
+++ b/jackm_carhack_nissan.md
@@ -51,7 +51,7 @@ This CAN interface is connected via USB to a laptop running Linux.
 Using the [SocketCAN](https://en.wikipedia.org/wiki/SocketCAN) driver to create a network interface (arbitrarily named "can0").
 
 Discovered via trial and error that the CAN bus bit rate on the Nissan Sentra is 500kbit/s.
-The the majority of passenger vehicles will use a CAN bus bit rate of either 250kbit/s or 500kbit/s.
+The majority of passenger vehicles will use a CAN bus bit rate of either 250kbit/s or 500kbit/s.
 
 Configuring the CAN network interface
 


### PR DESCRIPTION
Found by scanning all 401 root pages and 3364 links against the actual file tree and header slugs. Six small fixes across six files, no technical claims added.

### Broken links

- **X-tau-Wall-Wetting** — `![config](X-tau-Wall-Wetting)` pointed an image tag at a page name, so it rendered as a broken image. The intended file is already in the repo and unused: `Overview/wall_wetting/wall_wetting_sample_config.jpg`, sitting right beside the working `![log]` line just below it.
- **Mazda-Miata-1999** — the NB1 trigger link pointed at `All-Supported-Triggers#mazda-miata-nb`, which doesn't exist. The actual heading is `### MAZDA_MIATA_NB1`.

### Ignition index

`Pages-Ignition` listed 5 pages and was missing three that exist and have real content: **Ignition** (the timing/dwell overview, which had exactly one inbound link anywhere in the wiki), **Multi-Spark**, and **knock-sensing**.

### Typos

- `Dev-Console-Implementation`: recieved → received
- `Multi-Spark`: occured → occurred
- `jackm_carhack_nissan`: "The the" → "The"

### One thing deliberately not changed

`Mazda-Miata-2003` links to `Mazda-Miata-2002#starting-power`. Under GitHub's slugger the heading `## Starting & power` becomes `starting--power`, so that link looks broken — but `wiki-tools` builds wiki.rusefi.com with zensical / python-markdown, which collapses the whitespace and yields `starting-power`. The link is correct on the primary site, so changing it would break it there. Flagging rather than touching it, in case you want the heading reworded so both renderers agree.

For reference, the wiki is in good shape: 3364 links produced only these few real defects, and 401 pages produced two misspellings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
