### PR TITLE
docs: fix the Nissan heading and two dead anchors in the trigger index

### DIFF
--- a/All-Supported-Triggers.md
+++ b/All-Supported-Triggers.md
@@ -550,7 +550,7 @@ Chrysler NGC 6 cylinder
 
 ### 1.8t
 
-For cam trigger support check [Bosch Quick Start](#bosch-quick-start) if it is the '2 wide gaps 2 small gaps' cam trigger wheel, some earlier models instead use a cam trigger wheel with 1 missing tooth which can simply use single tooth trigger.
+For cam trigger support check [Bosch Quick Start](#vvt_bosch_quick_start) if it is the '2 wide gaps 2 small gaps' cam trigger wheel, some earlier models instead use a cam trigger wheel with 1 missing tooth which can simply use single tooth trigger.
 
 ## Miscellaneous
 
@@ -715,9 +715,7 @@ Use this cam trigger with special 3+0 symmetrical crank trigger.
 
 ![image](Images/TS/3000gt_trigger_offset_setup.png)
 
-## NISSAN_QR25
-
-Nissan
+## Nissan
 
 ### NISSAN_QR25
 
@@ -781,7 +779,7 @@ For historical reasons we support wrongfully wired 60-2
 
 ### 60_2_WRONG_POLARITY
 
-See also [Universal True 60/2](All-Supported-Triggers#602)
+See also [Universal True 60/2](All-Supported-Triggers#toothed_wheel_60_2)
 
 ![x](Images/triggers/trigger_TT_60_2_WRONG_POLARITY.png)
 


### PR DESCRIPTION
Items **1** and **3** from #719, as requested.

### 1. Missing Nissan category heading

The Nissan section opened with `## NISSAN_QR25`, followed by a loose `Nissan` paragraph, then `### NISSAN_QR25`. Every other make follows `## <Make>` → `### <TRIGGER>` → description:

```
## Honda          ## Mazda              ## GM
### 12 crank/...  ### MAZDA_SOHC_4      ### GM_7X
                  Mazda Protege SOHC    GM 7x
```

So the heading becomes `## Nissan` and the stray paragraph goes away. This also fixes `[Nissan](#nissan)` in the index at the top, which had no target — every other make's category link already worked.

### 3. Two anchors pointing at slugs that don't exist

- `[Bosch Quick Start](#bosch-quick-start)` → `#vvt_bosch_quick_start`, matching the `## VVT_BOSCH_QUICK_START` heading.
- `[Universal True 60/2](All-Supported-Triggers#602)` → `#toothed_wheel_60_2`. You asked me to confirm this one: the link sits inside `## 60_2_WRONG_POLARITY` ("60-2 with flipped wires ... for historical reasons we support wrongfully wired 60-2"), so the "true" 60/2 it contrasts against is `## TOOTHED_WHEEL_60_2`, whose description is simply "60/2". The other candidate, `### Universal skipped wheel`, is the generic any-tooth-count wheel, not 60/2 specifically.

### Verification

Re-ran the link scan: dead links in this file drop from **17 to 14**, and all three new targets resolve.

The remaining 14 are items **2** and **4** from #719 — the 13 TOC entries with no body section, and the missing `trigger_TT_THREE.png`. Both need someone who knows the triggers, so I've left them alone and #719 stays open for them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
