### PR TITLE
docs: complete the software and FAQ/HOWTO index pages

### DIFF
--- a/Pages-FAQ-and-HOWTO.md
+++ b/Pages-FAQ-and-HOWTO.md
@@ -3,17 +3,44 @@
 ## FAQs
 
 - [Ignition](FAQ-Ignition)
+- [Unsaved Changes Indicator](FAQ-Unsaved-Changes-Indicator)
+- [Why we no longer offer self-assembly ECUs](FAQ-Why-No-Self-Assembly)
 
 ## HOWTOs
 
+### Getting started
+
 - [Get Help](Support)
+- [Quick Start](HOWTO-quick-start)
+- [Get Running With a Universal ECU](HOWTO-Get-Running)
+- [Get Running With a Plug-and-Play ECU](HOWTO-Get-Running-PnP)
 - [Create a TunerStudio Project](HOWTO-create-tunerstudio-project)
-- [Basic Wiring and Connections](FAQ-Basic-Wiring-and-Connections)
-- [Crimp Ampseal](HOWTO-Crimp-Ampseal)
 - [Start an Engine](HOWTO-Start-An-Engine)
+
+### Wiring
+
+- [Basic Wiring and Connections](FAQ-Basic-Wiring-and-Connections)
+- [Crimping Hints](HOWTO-Crimp)
+- [Crimp Ampseal](HOWTO-Crimp-Ampseal)
+
+### Firmware
+
 - [Direct Firmware Update](HOWTO-DFU)
 - [Update Firmware](HOWTO-Update-Firmware)
+- [Flash using STM32CubeProgrammer](HOWTO-flash-using-Stm32CubeProgrammer)
+
+### Tuning and logging
+
 - [Upload a Tune](HOWTO-upload-tune)
 - [Upload a Log](HOWTO-upload-log)
+- [Remote Tuning](HOWTO-Remote-Tuning)
 - [Set Up Launch Control](HOWTO-Launch-Control)
+
+### Contributing
+
 - [Help rusEFI](HOWTO-help-rusEFI)
+- [Contribute to Documentation](HOWTO-contribute-to-documentation)
+- [Contribute to Firmware](HOWTO-contribute-to-firmware)
+- [Testing Documentation Changes](HOWTO-Test-Doc-Changes)
+- [Link Validation in Markdown Documents](HOWTO-validate-links)
+- [Search the Wiki](HOWTO-Search-on-rusEFI-wiki)

--- a/Pages-Software.md
+++ b/Pages-Software.md
@@ -4,6 +4,7 @@
 
 * [Preferred Code Style](Code-Style)
 * [Firmware Downloads](Download)
+* [Firmware Versions - Release vs Snapshot](Release-Snapshot-Latest-firmware)
 * [Feature ideas](I-have-an-idea)
 * [How To DFU](HOWTO-DFU)
 * [How To Update Firmware](HOWTO-Update-Firmware)
@@ -14,7 +15,21 @@
 
 <details markdown="1" class="abstract"><summary><u>Firmware Features</u></summary>
 
+* [Lua Scripting](Lua-Scripting)
 * [Password Protection](Password-Protection)
 * [Virtual Simulator](Virtual-simulator)
+
+</details>
+
+<details markdown="1" class="abstract"><summary><u>Tools and Services</u></summary>
+
+* [rusEFI Online - share tunes and logs](Online)
+
+</details>
+
+<details markdown="1" class="abstract"><summary><u>Development</u></summary>
+
+* [Custom rusEFI firmware for your own board](Custom-Firmware)
+* [Dev Console implementation](Dev-Console-Implementation)
 
 </details>


### PR DESCRIPTION
Both index pages were missing most of what they're meant to index. Every existing entry is kept — this is additive apart from one moved line, noted at the bottom.

### Pages-Software

Listed 9 entries, and **did not include Lua Scripting** — at ~2900 words the largest software page in the wiki. Added:

- **Lua Scripting**, under Firmware Features
- **Firmware Versions (Release vs Snapshot)**, next to Firmware Downloads
- **rusEFI Online**, under a new *Tools and Services* group
- **Custom firmware for your own board** and **Dev Console implementation**, under a new *Development* group

`TS-over-CAN` and `Bluetooth` were deliberately left out — they're already indexed in `Pages-Communications`, and a page listed in two indexes makes both harder to trust.

### Pages-FAQ-and-HOWTO

Listed **12 of the 35** `FAQ-*` / `HOWTO-*` pages, and its FAQs section had a single entry. Added the two missing FAQs, plus the general-purpose HOWTOs that weren't listed: Quick Start, Get Running (universal and PnP), Crimping Hints, Flash using STM32CubeProgrammer, Remote Tuning, Search the Wiki, and the four contributor guides.

The flat 11-item HOWTO list is now grouped under **Getting started / Wiring / Firmware / Tuning and logging / Contributing**, so 25 entries stay scannable.

**Only one existing line changed position** — "Start an Engine" moved up into *Getting started*. Everything else keeps its original order, so the diff is otherwise pure additions.

Vehicle-specific build guides (`HOWTO-M111-on-microRusEFI`, `HOWTO-M73-v12-on-Proteus`) were deliberately **not** added: they're already linked from their vehicle pages, and they'd crowd out the general-purpose HOWTOs. Happy to add them if you'd rather have them here.

All link targets verified against master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
