### PR TITLE
docs: surface the terminology glossary and fix its broken markup

### DIFF
--- a/Getting-Started.md
+++ b/Getting-Started.md
@@ -4,6 +4,8 @@ This page is an ordered roadmap for going from zero to a running, tunable rusEFI
 
 > New to the project? Skim the [rusEFI overview on the Home page](Home) first to see what rusEFI is and whether it fits your project.
 
+> Hitting unfamiliar abbreviations? EFI documentation is dense with them — CLT, MAP, TPS, ETB, baro, VVT and so on. They are all spelled out in [Acronyms & Terminology](Vault-Of-Terminology).
+
 ## 1. Choose your hardware
 
 Decide which ECU suits your engine and the features you need. rusEFI runs on two broad categories of hardware:

--- a/Vault-Of-Terminology.md
+++ b/Vault-Of-Terminology.md
@@ -18,6 +18,11 @@ AFR is the ratio of air to fuel, often expressed as "14.7:1"
 Air Intake Temperature
 </details>
 
+<details markdown="1"><summary><u>APP</u></summary>
+
+Accelerator Pedal Position - the sensor on the pedal itself in a drive-by-wire setup. Same as PPS. See also DBW, ETB
+</details>
+
 <details markdown="1"><summary><u>ATDC</u></summary>
 
 After TDC, After Top Dead Center - See also BTDC
@@ -66,6 +71,16 @@ Crankshaft Position Sensor
 <details markdown="1"><summary><u>CR</u></summary>
 
 Compression Ratio
+</details>
+
+<details markdown="1"><summary><u>DBW</u></summary>
+
+Drive By Wire - the throttle is opened by a motor under ECU control instead of a cable from the pedal. See also ETB, APP
+</details>
+
+<details markdown="1"><summary><u>DFU</u></summary>
+
+Device Firmware Update - the STM32 bootloader mode used to flash firmware over USB. See [How To DFU](HOWTO-DFU)
 </details>
 
 <details markdown="1"><summary><u>DI</u></summary>
@@ -150,6 +165,11 @@ A pushpull or HighLow is an output that is powered "high" (12v or 5v) and switch
 High and low resistance, used in terms of fuel injectors, normally around 14 ohms for high impedance and ~4 ohms for low.
 </details>
 
+<details markdown="1"><summary><u>IAC</u></summary>
+
+Idle Air Control - a valve that lets air bypass the closed throttle plate to control idle speed. See [Idle Control](Idle-Control)
+</details>
+
 <details markdown="1"><summary><u>IAT</u></summary>
 
 Intake Air Temperature
@@ -222,6 +242,11 @@ Manifold Absolute Pressure, often used in the context of load sensors.
 Mean Best Timing, used in context of spark timing, it is the spark timing that results in the best torque  
 </details>
 
+<details markdown="1"><summary><u>MCU</u></summary>
+
+Microcontroller Unit - the processor on the ECU board, for example an STM32F4 or STM32F7
+</details>
+
 <details markdown="1"><summary><u>MLV</u></summary>
 
 [MegaLogViewer](https://www.efianalytics.com/MegaLogViewer/)
@@ -245,6 +270,11 @@ Chrysler Next Generation Controller
 <details markdown="1"><summary><u>NTC</u></summary>
 
 Negative Temperature Coefficient, used in context of temperature sensors and refers to the resistance increasing as temperature decreases.  
+</details>
+
+<details markdown="1"><summary><u>OBD2</u></summary>
+
+On-Board Diagnostics II - the standard vehicle diagnostic protocol. rusEFI answers basic OBD2 requests so generic gauges and phone apps can read parameters
 </details>
 
 <details markdown="1"><summary><u>PIP</u></summary>
@@ -290,8 +320,8 @@ rusEFI
 <details markdown="1"><summary><u>RUSEFI</u></summary>
 
 Really Uber Simple EFI? Robust Ultra Simple EFI? Retarded Unproven Shitty EFI?
-</details
->
+</details>
+
 <details markdown="1"><summary><u>Secondary Coil</u></summary>
 
 The secondary winding of an ignition coil.  
@@ -353,6 +383,11 @@ The ideal quantity of fuel to burn with a quantity of air for complete combustio
 <details markdown="1"><summary><u>SOIC</u></summary>
 
 Small Outline Integrated Circuit  
+</details>
+
+<details markdown="1"><summary><u>TCU</u></summary>
+
+Transmission Control Unit - the controller for an automatic gearbox, separate from the engine ECU
 </details>
 
 <details markdown="1"><summary><u>TDC</u></summary>

--- a/_Sidebar.md
+++ b/_Sidebar.md
@@ -11,6 +11,7 @@
 - [How to create a TunerStudio project](HOWTO-create-tunerstudio-project)
 - [rusEFI Online](Online)
 - [FAQs and HOWTOs](Pages-FAQ-and-HOWTO)
+- [Acronyms & Terminology](Vault-Of-Terminology)
 
 ## Guides
 

--- a/generator/zensical.toml
+++ b/generator/zensical.toml
@@ -50,7 +50,8 @@ nav = [
     {"Support & Community" = "Support.md"},
     {"How to create a TunerStudio project" = "HOWTO-create-tunerstudio-project.md"},
     {"rusEFI Online" = "Online.md"},
-    {"FAQs and HOWTOs" = "Pages-FAQ-and-HOWTO.md"}
+    {"FAQs and HOWTOs" = "Pages-FAQ-and-HOWTO.md"},
+    {"Acronyms & Terminology" = "Vault-Of-Terminology.md"}
   ]},
   {"Guides" = [
     {"Wiring & Connectivity Overview" = "FAQ-Basic-Wiring-and-Connections.md"},


### PR DESCRIPTION
The wiki already has a good glossary. `Vault-Of-Terminology` defines ~85 acronyms including Baro, MAP, TPS, ETB, VVT, CLT, IAT and GDI. **The problem is that almost nobody can find it** — it had exactly one inbound link (`Pages-Info-Vaults`) and wasn't in the sidebar.

That matters because these abbreviations are used unexplained throughout the wiki. I scanned for pages that use an abbreviation and never expand it anywhere on that page:

| Abbreviation | Used on | Never expanded on |
|---|---|---|
| TPS | 46 pages | 33 |
| MAP | 41 pages | 35 |
| ETB | 37 pages | 24 |
| CLT | 30 pages | 15 |
| IAT | 26 pages | 13 |
| VVT | 24 pages | 20 |
| GDI | 23 pages | 21 |
| baro | 4 pages | 4 |

Expanding every instance in place would be a huge, unreviewable diff and a lot of churn on pages that are otherwise fine. Making the existing glossary easy to reach costs three lines and helps every one of those pages at once.

### Changes

- **Sidebar** — "Acronyms & Terminology" added under Getting Started.
- **Getting Started roadmap** — a short note pointing at the glossary, since that's where a newcomer meets these abbreviations first.
- **Rendering bug in the glossary.** The closing tag after the `RUSEFI` entry was split across two lines as `</details` followed by `>` on its own line, leaving **88 opening tags and 87 valid closes** — which breaks the collapsible from that point down. Now balanced at 95/95.
- **Seven missing abbreviations added**, each placed alphabetically: `APP`, `DBW`, `DFU`, `IAC`, `MCU`, `OBD2`, `TCU`. Definitions follow the existing terse style and link to the relevant wiki page where one exists.

Happy to also expand first use on the highest-traffic pages (Home, Getting Started, the board pages) as a follow-up if you'd like — I just didn't want to bundle a large mechanical edit with this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
