### PR TITLE
docs: put the ECU comparison in both navigations

### DIFF
--- a/_Sidebar.md
+++ b/_Sidebar.md
@@ -66,6 +66,7 @@
 ## ECU Hardware
 
 - [rusEFI Hardware Overview](Hardware)
+- [ECU Comparison](ECU-Comparison)
 
 ### Universal ECUs
 

--- a/generator/zensical.toml
+++ b/generator/zensical.toml
@@ -72,6 +72,7 @@ nav = [
   ]},
   {"ECU Hardware" = [
     {"rusEFI Hardware Overview" = "Hardware.md"},
+    {"ECU Comparison" = "ECU-Comparison.md"},
     {"Universal ECUs" = [
       {"uaEFI" = "uaEFI.md"},
       {"microRusEFI" = "microRusEFI-Manual.md"},


### PR DESCRIPTION
Follow-up to #724. That PR merged while GitHub still had its head pinned to the first commit, so the page landed but the navigation commit did not come with it.

Right now `ECU-Comparison` is live with exactly **one** inbound link — a single line on `Hardware` — and appears in neither navigation. To reach it you have to open the Hardware overview first and then spot the link, which is backwards for a page whose whole job is helping someone pick a board.

This adds it under **ECU Hardware**, directly after the Hardware overview, in both places that drive navigation:

- `_Sidebar.md` — drives the GitHub wiki mirror
- `generator/zensical.toml` — drives wiki.rusefi.com

Both are needed: `wiki-tools/run.sh` builds the site nav from `zensical.toml` and excludes `_Sidebar` entirely, so a sidebar-only entry would surface the page on the mirror but not on the main site.

Two lines total. TOML re-validated and every nav target resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
