### PR TITLE
docs: surface three orphaned pages from where they belong

### DIFF
--- a/Case-Studies.md
+++ b/Case-Studies.md
@@ -1,5 +1,7 @@
 # Case Studies
 
+See also [List of Engines Running rusEFI](List-of-Engines-Running-rusEFI) for the running log of builds going back to 2013.
+
 ![GTO race car](Images/gto.jpeg)
 
 ## 2024 Harley

--- a/Hardware.md
+++ b/Hardware.md
@@ -42,6 +42,9 @@ __A:__ There is no single right answer. It really depends on what kind of electr
 *__Q:__ What are these four status LEDs close to main processor?*  
 __A:__ Many rusEFI boards have four status LEDs. See [LED States](LED-states).
 
+*__Q:__ Does this come with a base map?*  
+__A:__ Please see [Does This Come With a Base Map?](Basemap)
+
 *__Q:__ Exciting! What soldering iron is best?*  
 __A:__ Please see [FAQ Why No Self Assembly](FAQ-Why-No-Self-Assembly)
 

--- a/Support.md
+++ b/Support.md
@@ -22,6 +22,8 @@ The [rusEFI Forum](https://rusefi.com/forum/) is the primary free support channe
 
 [Discord](https://discord.gg/rCGAUaZJKF) is a group messenger that can be accessed through your browser or as an application. This is a good place for quick one off questions, but not for continued help on a project, as context is very quickly lost in the stream.
 
+For the full list of channels and why the forum is preferred for anything worth keeping, see [Knowledge sharing and Channels](Knowledge-best-practices-and-Channels).
+
 ### How to ask for help
 
 Before getting in touch for some assistance there are a couple of things to know that will make it easy for us to help you.


### PR DESCRIPTION
Three pages with real content had **no inbound links from anywhere** in the wiki and were in neither navigation — reachable only by knowing the URL. Each is now linked from the page that should have been pointing at it. Three lines, nothing rewritten.

| Page | Now linked from | Why there |
|---|---|---|
| `Basemap` (52w) | Hardware FAQ | It answers "Does this come with a base map?" — a question people ask *before buying*, so it belongs next to the other purchase questions |
| `Knowledge-best-practices-and-Channels` (194w) | Support → "Where to ask for help" | It explains which channel to use and why the forum is preferred for anything worth keeping — exactly that section's subject |
| `List-of-Engines-Running-rusEFI` (744w) | Case Studies | It already links *to* Case Studies; now the link goes both ways |

The middle one seems worth the most: every board page says **"Community support ONLY"**, and the page explaining how that community actually works was invisible.

Deliberately does **not** touch `Pages-FAQ-and-HOWTO` — #722 is still open against that file and I didn't want to create a conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
