### PR TITLE
docs: add a master list of Vehicle pages

### DIFF
--- a/Pages-Vehicles.md
+++ b/Pages-Vehicles.md
@@ -1,0 +1,190 @@
+# Master list of Vehicle pages
+
+Pages covering specific vehicles and engines. These are community build notes rather than official installation manuals — depth varies a lot, from full write-ups to a couple of part numbers.
+
+Looking for a plug-and-play board for your car instead? See [Hardware](Hardware) and the [ECU Comparison](ECU-Comparison). For wiring that is not vehicle-specific, see the [Wiring & Connectivity Overview](FAQ-Basic-Wiring-and-Connections).
+
+<details markdown="1" class="abstract"><summary><u>Acura</u></summary>
+
+* [Acura RSX](Acura-RSX)
+* [Acura TSX](Acura-TSX)
+
+</details>
+
+<details markdown="1" class="abstract"><summary><u>Audi and Volkswagen</u></summary>
+
+* [2002 Audi Allroad](2002-Allroad)
+* [Audi A4 B7 2.0 TFSI (2006)](Audi-A4-2.0T-2006)
+* [VAG B5 platform](VAG-B5)
+* [2002 VW Passat](2002-Passat)
+* [VW Passat 2002 1.8](VW-Passat-2002-1.8)
+* [Volkswagen Passat B6](VolkswagenPassatB6)
+* [Passat GDI wiring](Passat-GDI-wiring)
+
+</details>
+
+<details markdown="1" class="abstract"><summary><u>BMW</u></summary>
+
+* [BMW 7 Series (E38)](BMW-e38)
+* [1996 BMW E38 750](BMW-e38-1996-750)
+* [BMW e38 750](BMW-e38-750)
+* [BMW e38 part numbers](BMW-e38-Part-Numbers)
+* [BMW 5 Series (E39)](BMW-e39)
+* [BMW e46](BMW-e46)
+* [BMW E65](BMW-e65)
+* [E65 CAN bus](E65-CAN-bus)
+* [E65 CAN](e65-can)
+* [N52 engine](BMW-N52)
+* [N73 engine](BMW-N73)
+* [BMW S1000RR](BMW-S1000RR)
+* [2003 Mini Cooper](Mini-Cooper-2003)
+
+</details>
+
+<details markdown="1" class="abstract"><summary><u>Chevrolet and GM</u></summary>
+
+* [1998 Chevrolet Blazer S10 V6](Chevrolet-Blazer-S10-V6-1998)
+* [GM E38](GM-E38)
+* [GM E67](GM-E67)
+
+</details>
+
+<details markdown="1" class="abstract"><summary><u>Dodge and Chrysler</u></summary>
+
+* [2003 Dodge Neon](Dodge-Neon-2003)
+* [1996 Dodge Ram 1500](Dodge-Ram-1500-1996)
+
+</details>
+
+<details markdown="1" class="abstract"><summary><u>Ford</u></summary>
+
+* [1992 Ford Mustang 5.0](Mustang-Ford-92-5.0)
+
+</details>
+
+<details markdown="1" class="abstract"><summary><u>Harley-Davidson</u></summary>
+
+* [Harley Davidson](Harley-Davidson)
+* [Harley-Davidson 81](Harley-81)
+
+</details>
+
+<details markdown="1" class="abstract"><summary><u>Honda</u></summary>
+
+* [1995 Honda Accord](Honda-Accord-1995)
+* [1996 Honda Civic](Honda-Civic-1996)
+* [1993 Honda Prelude](Honda-Prelude-1993)
+* [Honda S2000](Honda-S2000)
+* [Honda TPMS CAN trick](Honda-TPMS-CAN-trick)
+
+</details>
+
+<details markdown="1" class="abstract"><summary><u>Hyundai</u></summary>
+
+* [2004 Hyundai Elantra](Hyundai-Elantra-2004)
+* [Hyundai Genesis Coupe](Hyundai-Genesis-Coupe)
+
+</details>
+
+<details markdown="1" class="abstract"><summary><u>Mazda</u></summary>
+
+* [Mazda Miata overview](Miata)
+* [Miata readme](miata-readme)
+* [1990 Miata](Mazda-Miata-1990)
+* [1991 Miata](Mazda-Miata-1991)
+* [1994 Miata](Mazda-Miata-1994)
+* [1995 Miata](Mazda-Miata-1995)
+* [1996 Miata](Mazda-Miata-1996)
+* [1997 Miata](Mazda-Miata-1997)
+* [1999 Miata](Mazda-Miata-1999)
+* [2001 Miata](Mazda-Miata-2001)
+* [2001 Miata ABS](Mazda-Miata-2001-ABS)
+* [2002 Miata](Mazda-Miata-2002)
+* [2003 Miata](Mazda-Miata-2003)
+* [2003 Miata alt](Mazda-Miata-2003-alt)
+* [2005 Miata](Mazda-Miata-2005)
+* [2005 Mazdaspeed Miata](Mazdaspeed-Miata-2005)
+* [2011 Miata](Mazda-Miata-2011)
+* [Miata NB1](Mazda-Miata-NB1)
+* [Miata NB2](Mazda-Miata-NB2)
+* [Miata NC](Miata-NC)
+* [Miata VTPS adapter bracket](Miata-VTPS-Adapter-Bracket)
+* [Mazda PRC valve](Mazda-PRC-Valve)
+* [2004 Mazda RX8](Mazda-RX8-2004)
+* [2005 Mazda RX8](Mazda-RX8-2005)
+* [2007 Mazda RX8](Mazda-RX8-2007)
+
+</details>
+
+<details markdown="1" class="abstract"><summary><u>Mercedes-Benz</u></summary>
+
+* [1997 E320](1997-e320)
+* [1999 E320](1999-e320)
+* [1999 E430](1999-e430)
+* [2000 S430](2000-s430)
+* [C230 and SLK230](Mercedes-C230-and-SLK230)
+* [Mercedes overview](Mercedes)
+
+</details>
+
+<details markdown="1" class="abstract"><summary><u>Mitsubishi</u></summary>
+
+* [1995 Mitsubishi 3000GT](1995-3000gt)
+* [Mitsubishi 3000GT](3000gt)
+* [Mitsubishi Lancer](Mitsubishi-Lancer)
+
+</details>
+
+<details markdown="1" class="abstract"><summary><u>Nissan</u></summary>
+
+* [Nissan 370Z CAN data](Knio_carhack_Nissan)
+* [Nissan Sentra 2010 CAN bus data](jackm_carhack_nissan)
+* [2011 Nissan Xterra](Nissan-Xterra-2011)
+* [2011 Nissan Xterra CAN](Nissan-Xterra-2011-CAN)
+
+</details>
+
+<details markdown="1" class="abstract"><summary><u>Porsche</u></summary>
+
+* [2004 Porsche Cayenne](2004-Cayenne)
+
+</details>
+
+<details markdown="1" class="abstract"><summary><u>Saab</u></summary>
+
+* [2005 Saab 9-3](Saab-9-3-2005)
+* [Reverse engineering the Saab Trionic 8 combustion detection module](Saab-Trionic-8-Combustion-Detection-Module-on-Mazda-Miata-running-rusEFI)
+
+</details>
+
+<details markdown="1" class="abstract"><summary><u>Subaru</u></summary>
+
+* [1991-1996 Subaru Impreza](Subaru-Impreza-1991-1996)
+* [1993 Subaru Impreza](Subaru-Impreza-1993)
+
+</details>
+
+<details markdown="1" class="abstract"><summary><u>Toyota</u></summary>
+
+* [Toyota overview](Toyota)
+* [Toyota 4Runner](Toyota-4Runner)
+* [Toyota Camry 2001 LE 3.0](Toyota-Camry-2001-LE-3.0)
+* [Toyota JZ](Toyota-JZ)
+
+</details>
+
+<details markdown="1" class="abstract"><summary><u>Other makes</u></summary>
+
+* [Kawasaki](Kawasaki)
+* [Lada M86](lada-m86-readme)
+* [Maserati / Ferrari F136](Maserati-Ferrari-F136)
+* [Volvo](Volvo)
+
+</details>
+
+## Related pages
+
+* [Case Studies](Case-Studies) — notable builds
+* [List of Engines Running rusEFI](List-of-Engines-Running-rusEFI) — running log of builds since 2013
+* [Hardware](Hardware) and [ECU Comparison](ECU-Comparison) — choosing a board
+* [All Supported Triggers](All-Supported-Triggers) — finding your trigger pattern

--- a/_Sidebar.md
+++ b/_Sidebar.md
@@ -86,6 +86,7 @@
 
 ## Index
 
+- [Vehicles](Pages-Vehicles)
 - [Fuel](Pages-Fuel)
 - [Sensors and Actuators](Pages-Sensors-and-Actuators)
 - [Ignition](Pages-Ignition)

--- a/generator/zensical.toml
+++ b/generator/zensical.toml
@@ -88,6 +88,7 @@ nav = [
 		{"Other Hardware" = "Other-Hardware.md"}
   ]},
   {"Index" = [
+    {"Vehicles" = "Pages-Vehicles.md"},
     {"Fuel" = "Pages-Fuel.md"},
     {"Sensors and Actuators" = "Pages-Sensors-and-Actuators.md"},
     {"Ignition" = "Pages-Ignition.md"},


### PR DESCRIPTION
The wiki has around **90 pages covering specific vehicles and engines** — roughly a fifth of everything — and there was **no index for them and no vehicle section in either navigation**. The pages link to each other and to vault pages, but there was no way to browse *"what does rusEFI have for my car"*.

Every other topic area has an index (`Pages-Fuel`, `Pages-Ignition`, `Pages-Software`, `Pages-Sensors-and-Actuators`, `Pages-Communications`, `Pages-Info-Vaults`). Vehicles — the largest group — didn't.

### What's in it

92 entries grouped by manufacturer, using the same `<details class="abstract">` layout as the other indexes:

Acura · Audi and Volkswagen · BMW · Chevrolet and GM · Dodge and Chrysler · Ford · Harley-Davidson · Honda · Hyundai · Mazda · Mercedes-Benz · Mitsubishi · Nissan · Porsche · Saab · Subaru · Toyota · other makes

Added to the **Index** section of both `_Sidebar.md` and `generator/zensical.toml`, so it's reachable on the GitHub mirror and on wiki.rusefi.com.

### Two things stated on the page

- **These are community build notes, not installation manuals**, and depth varies — entries range from full write-ups to a couple of part numbers. Better to say that than let someone open a nine-word page expecting a manual.
- **Anyone looking for a plug-and-play board is pointed at `Hardware` and `ECU-Comparison` instead**, since "which ECU fits my car" is a different question from "what notes exist for my car". PnP board pages are deliberately not listed here.

Every one of the 94 link targets was verified to resolve, and the collapsibles balance 18/18.

One thing the index makes visible rather than hides: `E65-CAN-bus` and `e65-can` are both listed, because both exist. That's the near-duplicate pair worth a decision at some point — merge or differentiate — but I didn't want to silently drop one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
