### PR TITLE
docs: point the site nav Proteus entry at the current manual

### DIFF
--- a/generator/zensical.toml
+++ b/generator/zensical.toml
@@ -77,7 +77,7 @@ nav = [
     {"Universal ECUs" = [
       {"uaEFI" = "uaEFI.md"},
       {"microRusEFI" = "microRusEFI-Manual.md"},
-      {"Proteus" = "Proteus.md"}
+      {"Proteus" = "Proteus-Manual.md"}
     ]},
     {"Plug-and-Play ECUs" = [
       {"Honda OBD1" = "uaEFI-Honda-OBD1.md"},


### PR DESCRIPTION
On wiki.rusefi.com, **ECU Hardware → Universal ECUs → Proteus** leads to `Proteus.md`, whose first line is:

```
# Proteus - OLD PAGE

[Current Proteus Manual](Proteus-Manual)
```

So the site navigation sends people to a page that immediately tells them they're in the wrong place — on one of the eight universal boards.

The GitHub sidebar already points at `Proteus-Manual`. This makes `generator/zensical.toml` agree with it. One line.

`Proteus.md` is **not** touched — it still holds unique content (Ampseal connectors, 3D cases, dev access, wiring, and the adapter lists), and `Proteus-Manual` already links to it for that detail. Only the navigation entry changes.

While in there I checked the rest of both navigations:

- **This was the only label pointing at different pages** between `_Sidebar.md` and `zensical.toml`.
- **It was the only page either navigation reached whose title marks it as old or deprecated.**

So this looks isolated rather than symptomatic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
