### PR TITLE
docs: say what the Other Hardware and Digital Dash options actually are

### DIFF
--- a/Digital-Dash.md
+++ b/Digital-Dash.md
@@ -1,6 +1,8 @@
 # Digital Dash
 
-See also: [Dash-hardware-comparison](Dash-hardware-comparison)
+A digital dash displays live engine data — RPM, coolant temperature, boost, lambda and so on — on a screen instead of analogue gauges. rusEFI does not care which one you use; what differs is the hardware, how it receives data, and how long it takes to come up.
+
+See also: [Dash hardware comparison](Dash-hardware-comparison) for the platform trade-offs, and [CAN Broadcast for Dashboards and Gauges](CAN-Broadcast-for-Dashboards) for how to get data out of the ECU and onto the dash.
 
 ## Summary
 
@@ -13,3 +15,20 @@ We have five versions of Digital Dash currently.
 3. A custom digital gauge cluster such as [uaDash](uaDASH) or [PiDGC](https://github.com/joshellissh/pidgc) ([Example on Josh's blog](https://mycustomcars.us/custom-digital-gauge-cluster/))
 4. An Android tablet or phone running an app such as [Real Dash](http://realdash.net/index.php), [Shadow Dash](Shadow-Dash), or [MSDroid](MSDroid)
 5. [combo10](combo10), a 10-inch touchscreen dashboard with a customizable gauge layout, an initial engine-configuration wizard, and limited on-device tuning. A Windows Dash Simulator is available to try the interface without hardware.
+
+## Things to weigh up
+
+**Boot time.** This is the open question above, and it is worth taking seriously: a dash that takes thirty seconds to appear is a dash that is blank every time you start the car. A dedicated device generally comes up faster than a general-purpose computer running a tuning application.
+
+**How it gets its data.** Most options read the [CAN broadcast](CAN-Broadcast-for-Dashboards), which is one-way and needs only CAN wiring between the ECU and the dash. A phone or tablet usually reaches that broadcast through a Bluetooth CAN adapter. Options that instead speak the TunerStudio protocol over serial are doing something different — see [Bluetooth](Bluetooth) for the limits of that path, including the fact that iOS cannot use it.
+
+**Whether you need to tune on it.** Most dashes only display. TunerStudio on a Raspberry Pi and combo10 can also change settings, which matters if you want one screen in the car rather than a dash plus a laptop.
+
+**Temperature and vibration.** A dash lives on a dashboard, which gets hot and shakes. [Dash hardware comparison](Dash-hardware-comparison) lists operating temperature as a differentiator between the platforms.
+
+## Related pages
+
+* [CAN Broadcast for Dashboards and Gauges](CAN-Broadcast-for-Dashboards) — getting data from the ECU to the dash
+* [Dash hardware comparison](Dash-hardware-comparison) — platform trade-offs for building your own
+* [Other Hardware](Other-Hardware) — uaDASH and other modules
+* [Bluetooth](Bluetooth) — wireless options and their limits

--- a/Other-Hardware.md
+++ b/Other-Hardware.md
@@ -1,26 +1,53 @@
 # Other Hardware
 
-## Electronics
+Modules and add-on boards that are not engine ECUs. For the ECUs themselves see [Hardware](Hardware) and the [ECU Comparison](ECU-Comparison).
 
-| Hardware                                       | Purchase                                                            |
-|------------------------------------------------|---------------------------------------------------------------------|
-| [Small CAN Board](Small-CAN-Board)             | [rusEFI Store](https://www.shop.rusefi.com/shop/p/smallcanboard)    |
-| [uaCanBridge](uaCanBridge)                     | [rusEFI Store](https://www.shop.rusefi.com/shop/p/ua-can-bridge)    |
-| [Dual Channel WBO](rusEFI-Wideband-Controller) | [rusEFI Store](https://www.shop.rusefi.com/shop/p/dual-channel-wbo) |
-| [uaWBO](uaWBO)                                 | [rusEFI Store](https://www.shop.rusefi.com/shop/p/uawbo)            |
-| [GDI4](GDI4)                                   | [rusEFI Store](https://www.shop.rusefi.com/shop/p/gdi4)             |
-| [GDI8](GDI8)                                   | [rusEFI Store](https://www.shop.rusefi.com/shop/p/gdi8)             |
-| [mega100](mega100)                             | [rusEFI Store](https://www.shop.rusefi.com/shop/p/mega100-f4)       |
-| [mega144](mega144)                             | [rusEFI Store](https://www.shop.rusefi.com/shop/p/mega144)          |
-| [uaDASH](uaDASH)                               | [rusEFI Store](https://www.shop.rusefi.com/shop/p/uadash7)          |
-| [Purple Gateway](purple-gateway)           |                                                                     |
+## CAN modules and gateways
 
-## Adapters
+| Hardware | What it is | Purchase |
+|---|---|---|
+| [Small CAN Board](Small-CAN-Board) | A CAN-bus module running full rusEFI firmware with [Lua](Lua-Scripting), for building your own controller — a smart wastegate, auxiliary lighting, whatever the I/O supports. Two CAN buses, LIN/K-line, CAN wake-up and very low standby current. | [rusEFI Store](https://www.shop.rusefi.com/shop/p/smallcanboard) |
+| [uaCanBridge](uaCanBridge) | Three-channel CAN-FD gateway, programmable with [Lua](Lua-Scripting). | [rusEFI Store](https://www.shop.rusefi.com/shop/p/ua-can-bridge) |
+| [Purple Gateway](purple-gateway) | Supplies engine data over CAN to an OEM transmission control unit so the gearbox can run without the original engine electronics. Current focus is Dodge and BMW 8HP, plus GM 6, 8 and 10 speed. | |
 
-[Proteus to Honda OBD2A](Proteus-HondaOBD2A)
+## Wideband oxygen controllers
 
-[Proteus to Honda 125](Proteus-Honda125)
+| Hardware | What it is | Purchase |
+|---|---|---|
+| [Dual Channel WBO](rusEFI-Wideband-Controller) | Two-channel wideband controller reporting over CAN. | [rusEFI Store](https://www.shop.rusefi.com/shop/p/dual-channel-wbo) |
+| [uaWBO](uaWBO) | Compact wideband controller with both CAN and analog output. | [rusEFI Store](https://www.shop.rusefi.com/shop/p/uawbo) |
 
-[Proteus to BMW M54](Proteus-BMW-M54)
+See [Wide Band Sensors](Wide-Band-Sensors) for choosing and wiring the sensor itself.
 
-[Proteus to Mitsubishi 76](Proteus-mitsubishi76)
+## Direct injection drivers
+
+These drive GDI injectors and the high pressure fuel pump. They are **not** standalone ECUs — you use them alongside one. See [GDI status](GDI-status).
+
+| Hardware | What it is | Purchase |
+|---|---|---|
+| [GDI4](GDI4) | Four-injector GDI driver with high pressure pump control. | [rusEFI Store](https://www.shop.rusefi.com/shop/p/gdi4) |
+| [GDI8](GDI8) | Eight injectors and two high pressure pumps — effectively two GDI4 boards in one. Note the warnings on its page about main-ECU integration. | [rusEFI Store](https://www.shop.rusefi.com/shop/p/gdi8) |
+
+## Arduino form factor boards
+
+For converting legacy Arduino-based hardware to rusEFI. Both need injector MOSFETs that can be driven from 3.3 V.
+
+| Hardware | What it is | Purchase |
+|---|---|---|
+| [mega100](mega100) | mega2560 form factor board on an STM32F4. | [rusEFI Store](https://www.shop.rusefi.com/shop/p/mega100-f4) |
+| [mega144](mega144) | The same idea on an STM32F7, giving more memory and more [Lua](Lua-Scripting) capacity. | [rusEFI Store](https://www.shop.rusefi.com/shop/p/mega144) |
+
+## Dash
+
+| Hardware | What it is | Purchase |
+|---|---|---|
+| [uaDASH](uaDASH) | Digital gauge cluster hardware. See [Digital Dash](Digital-Dash) for all dash options and [Dash hardware comparison](Dash-hardware-comparison) for the platform trade-offs. | [rusEFI Store](https://www.shop.rusefi.com/shop/p/uadash7) |
+
+## Proteus adapters
+
+Adapter boards that connect a [Proteus](Proteus-Manual) to a factory harness.
+
+* [Proteus to Honda OBD2A](Proteus-HondaOBD2A)
+* [Proteus to Honda 125](Proteus-Honda125)
+* [Proteus to BMW M54](Proteus-BMW-M54)
+* [Proteus to Mitsubishi 76](Proteus-mitsubishi76)


### PR DESCRIPTION
Both pages are in both navigations, and both listed options **without describing any of them**.

### Other Hardware (92 → 412 words)

It was a table of ten product names and store links. "Small CAN Board", "uaCanBridge", "mega100", "GDI4" tell a reader nothing — so the page couldn't answer the question it exists to answer.

Same products, now grouped by what they're *for* — CAN modules and gateways, wideband controllers, direct injection drivers, Arduino form factor boards, dash, Proteus adapters — each with a one-line description taken from its own page.

Two things worth having on the index rather than only on the product page:

- **The GDI boards are drivers, not standalone ECUs**, and are used alongside one. Easy to misread from a list titled "Other Hardware".
- **The mega boards need MOSFETs drivable from 3.3 V.**

### Digital Dash (117 → 425 words)

It listed five options and linked the hardware comparison, but never said **how a dash actually receives data** — and didn't link `CAN-Broadcast-for-Dashboards`, which is the page that answers that and which already links back here. That link was one-way.

Added a "things to weigh up" section: boot time (which the page's own summary raises as an open question and then drops), how data reaches the dash, whether an option can tune as well as display, and temperature/vibration.

### Preserved

The existing Summary wording and the numbered list of five dash options are unchanged. Verified nothing was dropped: **all 14 hardware entries, all 9 store links, all 5 dash options**, and every link target resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
