### PR TITLE
docs: add a Transmission Control hub and surface it

### DIFF
--- a/8hp.md
+++ b/8hp.md
@@ -1,6 +1,6 @@
 # 8HP Transmission
 
-[💜Purple Gateway💜](purple-gateway)
+[💜Purple Gateway💜](purple-gateway) · [Transmission Control overview](Transmission-Control)
 
 ## As of June 2026, we work on both 1st generation BMW F-series transmissions and Dodge/Chrysler
 

--- a/Home.md
+++ b/Home.md
@@ -54,7 +54,7 @@ In order to use rusEFI you will need to acquire one of the [supported control un
 | [Knock Sensing & Response](knock-sensing)                                                                   | ✓          |
 | [Kick Start](Kick-Start)                                                                                    | ✓          |
 | [Rotary Engines](Rotary)                                                                                    | ✓          |
-| [Automatic Transmission Control](TCU-status)                                                                | ✗          |
+| [Automatic Transmission Control](Transmission-Control)                                                      | ✓          |
 
 And many more!
 The unsupported features listed here are all things that would be amazing to see! If *you* have a project that includes any of those configurations or anything else, please jump in on the forums and we can work together to make it happen! 👍

--- a/TCU-status.md
+++ b/TCU-status.md
@@ -1,5 +1,7 @@
 # TCU Status
 
+See [Transmission Control](Transmission-Control) for an overview of the available approaches and which one suits your gearbox.
+
 ## Terminology
 
 First we need to establish good terminology.

--- a/Transmission-Control.md
+++ b/Transmission-Control.md
@@ -1,0 +1,98 @@
+# Transmission Control
+
+rusEFI can run an automatic transmission, but not in one single way — what you need depends on how old the transmission is and how it is controlled. This page is the starting point.
+
+The short version: **for older solenoid-controlled transmissions rusEFI can drive the transmission itself. For modern transmissions rusEFI talks to the factory transmission controller over CAN rather than replacing it**, and the [Purple Gateway](purple-gateway) is the module that does that.
+
+## Which approach do I need?
+
+| Your transmission | Approach | Start here |
+|---|---|---|
+| Older, controlled by simple solenoids — GM 4Lxx, Ford 4R70W and similar | rusEFI drives the transmission directly with its built-in TCU logic, or with a Lua script | [TCU Status](TCU-status) |
+| Modern ZF 8HP, or GM 6L / 8L / 10L | The factory TCU stays and keeps control of the solenoids. rusEFI feeds it the engine data it expects, over CAN, through the [Purple Gateway](purple-gateway) | [Purple Gateway](purple-gateway), [8HP](8hp) |
+| Something else, or you want to do the CAN work yourself | Write your own CAN integration | [How To Make Your Own ECU Communicate with TCU](HOWTO-Make-Your-Own-ECU-Communicate-with-TCU) |
+
+Modern transmissions use clutch-to-clutch control, where one clutch engages as another releases. rusEFI deliberately does not try to re-implement that: as [TCU Status](TCU-status) puts it, *"CAN bus integration with the OEM TCU is the only way for modern transmissions"*.
+
+A note on words, because they get mixed up: a **TCU** is wired to the transmission solenoids and actually controls them. A **CAN gateway** sits between the engine ECU and the TCU and translates. A **PCM** is one box doing both, which is how Ford, Toyota and Honda usually do it. Full definitions are on [TCU Status](TCU-status).
+
+## Purple Gateway
+
+[Purple Gateway](purple-gateway) is a CAN module that supplies a factory transmission controller with the engine data it needs, so the gearbox works without the original engine electronics behind it.
+
+**It is not a standalone TCU.** The factory TCU still controls the solenoids. The gateway's job is to make that TCU believe it is still installed in its original car.
+
+### What your engine side must provide
+
+The gateway needs four things to run an 8HP:
+
+| Data | Notes |
+|---|---|
+| Engine RPM | |
+| Driver intent | Pedal position sensor on a drive-by-wire setup, or [TPS](Throttle-and-Pedal-Sensors) on a cable throttle |
+| Torque | Either real torque from the ECU, or torque estimated from the [MAP sensor](MAP-Sensor) |
+| Brake | Brake pedal switch, or brake pedal pressure |
+
+Torque is the one people underestimate. Shift quality depends on the engine reducing and restoring torque on cue, which is why the gateway needs an ECU it can coordinate with. Without that coordination shifts will work, but they will not be smooth.
+
+### Supported transmissions
+
+| Transmission | Status |
+|---|---|
+| Dodge / Chrysler 8HP | Ready |
+| BMW F-series 8HP | Partly ready |
+| GM 6L | Beta |
+| GM 8L | Beta |
+| GM 10L | In progress |
+
+### Supported engine ECUs
+
+Torque coordination only works with an engine ECU the gateway knows how to talk to. As of the [Purple Gateway](purple-gateway) page, for 8HP that is:
+
+| Engine ECU | Status |
+|---|---|
+| OEM BMW E9x and siblings | Supported |
+| OEM BMW E46 and siblings such as E39 | Supported |
+| rusEFI | Coming |
+| GM E38 | Coming |
+| Generic legacy | Coming |
+
+If your engine is run by something not on that list, check with the project before buying — this is the question the gateway's own FAQ asks first.
+
+### Also worth knowing
+
+* It has a **built-in ZF flasher**, useful for backing up a TCU or moving it between brands.
+* The connector is **Superseal 26 pin**; harness side `3-1437290-8`.
+* The TCU gateway feature is **not open source**, unlike the rusEFI firmware.
+* It looks like the [nano](nano) ECU but is a completely different device.
+
+## ZF 8HP
+
+The [8HP](8hp) page covers the transmission family itself — which generations are worth using, and what a swap involves:
+
+* **BMW F-series** is the most available and bolts into older BMWs.
+* **BMW 2nd generation** such as 8HP50 shifts faster but does not bolt into older BMWs.
+* **Chrysler / Dodge** uses a physically interchangeable TCU but a completely different CAN dialect, and some versions have a trans brake.
+
+Two practical points from that page that catch people out:
+
+* **ISN reset.** A used 8HP arrives locked to the donor car's VIN and security data. The controller has to be reset before it will work in your car — see [BMW 8hp](Bmw-8hp).
+* **Power.** Constant power is ideal so the TCU can save its adaptations. If you must use switched power, use a 60 second time-delay relay.
+
+Vehicle-specific notes: [BMW 8hp](Bmw-8hp) and [Dodge 8hp](Dodge-8hp).
+
+## Older transmissions
+
+rusEFI has basic TCU logic of its own. A Ford 4R70W has driven under rusEFI TCU control, and there is code for GM 4Lxx transmissions with little real-world testing so far. There is also an alternative Lua approach for direct control of older transmissions — see [Lua Scripting](Lua-Scripting).
+
+Reference material for specific units: [NAG1 722.6](NAG1---722.6) and [How To TCU A42DE on Proteus](HOWTO-TCU-A42DE-on-Proteus).
+
+## Related pages
+
+* [Purple Gateway](purple-gateway) — the module, its pinout, changelog and FAQ
+* [8HP](8hp) — the transmission family
+* [TCU Status](TCU-status) — terminology and what is implemented
+* [How To Make Your Own ECU Communicate with TCU](HOWTO-Make-Your-Own-ECU-Communicate-with-TCU) — doing the CAN work yourself
+* [GM 6L transmissions](GM-6L)
+* [Sequential Transmission](Sequential-Transmission) — automated manual, a different thing entirely
+* [Other Hardware](Other-Hardware) — the rest of the add-on modules

--- a/_Sidebar.md
+++ b/_Sidebar.md
@@ -57,6 +57,7 @@
 - [Flat Shifting](Flat-Shifting)
 - [Boost Control](Boost-Control)
 - [Traction Control](Traction-Control)
+- [Transmission Control](Transmission-Control)
 
 ### Dash & Connectivity
 

--- a/generator/zensical.toml
+++ b/generator/zensical.toml
@@ -69,7 +69,8 @@ nav = [
     {"Variable Valve Timing" = "VVT.md"},
     {"Lua Scripting" = "Lua-Scripting.md"},
     {"Digital Dash" = "Digital-Dash.md"},
-    {"Multispark" = "Multi-Spark.md"}
+    {"Multispark" = "Multi-Spark.md"},
+    {"Transmission Control" = "Transmission-Control.md"}
   ]},
   {"ECU Hardware" = [
     {"rusEFI Hardware Overview" = "Hardware.md"},

--- a/purple-gateway.md
+++ b/purple-gateway.md
@@ -2,6 +2,8 @@
 
 The rusEFI Purple Gateway is a CANbus module that provides necessary engine data to an OEM transmission control unit, allowing it to function independently of the original engine electronics. At the moment our focus is Dodge and BMW 8HP, also GM 6-8-10 speed.
 
+New to this? [Transmission Control](Transmission-Control) explains where the Purple Gateway fits and whether it is the right approach for your gearbox.
+
 * [⏩ Interactive Pinout ⏪](https://rusefi.com/docs/pinouts/purple-gateway)
 * Available at the [rusEFI store](https://www.shop.rusefi.com/shop/p/purple-gateway)
 * It's not a standalone TCU: The OEM TCU controls the transmission solenoids.


### PR DESCRIPTION
Transmission control is a shipping capability with a product behind it, and it was close to invisible.

**None of the transmission pages were in either navigation.** `8hp` was three hops from anywhere — Other Hardware → Purple Gateway → 8hp — and nothing on the way said "transmission". Meanwhile the Purple Gateway page's own FAQ says:

> **Q: Documentation is bad** — *"yes, documentation is bad. TCU gateway is maybe 3rd or 4th priority for us right now."*

So this is me taking that at face value. Everything here is assembled from what your pages already say; nothing is invented.

### The new page

`Transmission-Control` answers the question people actually arrive with — *which approach does my gearbox need* — and splits the three paths:

| Transmission | Approach |
|---|---|
| Older solenoid-controlled (GM 4Lxx, Ford 4R70W) | rusEFI's own TCU logic, or Lua |
| Modern 8HP, GM 6L/8L/10L | Purple Gateway — factory TCU keeps control |
| Anything else | Write your own CAN integration |

For the **Purple Gateway** it lifts the buying-decision facts out of the FAQ where they were buried:

- The four things the engine side must provide — RPM, driver intent, torque (real or MAP-estimated), brake
- Which transmissions are **ready vs beta vs in progress**
- **Which engine ECUs it can coordinate torque with today** — this is the one that matters most and was hardest to find, since "rusEFI" is still listed as coming
- That it is *not* a standalone TCU, and shift quality depends on torque coordination

It also surfaces two things from the `8hp` page that catch people out: a used 8HP is locked to the donor VIN and needs an **ISN reset**, and the TCU wants **constant power or a 60-second time-delay relay** to save adaptations.

### Navigation and links

Added under Guides in both `_Sidebar.md` and `generator/zensical.toml`. Back-links from `purple-gateway`, `TCU-status` and `8hp`, so the cluster connects in both directions rather than one-way.

### One thing to check — the Home feature table

That row said:

```
| [Automatic Transmission Control](TCU-status)   | ✗ |
```

I retargeted it to the new page and changed it to ✓, because rusEFI sells a module for this, `TCU-status` records that a Ford 4R70W has driven under rusEFI TCU control, and there's GM 4Lxx code plus a Lua path.

**But I might be misreading your intent** — ✗ may have meant "not natively in the ECU itself", which is also fair given the gateway is a separate, closed-source device. The text under the table treats ✗ as "help wanted", which supports that reading.

Happy to flip it straight back to ✗ and keep only the improved link target. Just say.

### Left alone

`Bmw-8hp`, `Dodge-8hp` and `NAG1---722.6` are linked rather than absorbed. They're the vehicle-shaped pages, and if those relocate later the hub still stands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
