### PR TITLE
docs: expand the Rotary Engines page and put it in the navigation

### DIFF
--- a/Rotary.md
+++ b/Rotary.md
@@ -2,8 +2,52 @@
 
 We support running a rotary engine on [all our universal ECUs](Hardware). We have tested trailing coil logic.
 
-Some control hardware still needs attention; see [this GitHub issue](https://github.com/rusefi/rusefi/issues/3247).
+A Wankel rotary is mostly an ordinary engine as far as the ECU is concerned — it wants fuel and spark at the right moment like anything else. The one thing that genuinely differs is ignition: each rotor housing has **two spark plugs**, a leading and a trailing, and the trailing plug fires a short time after the leading one. rusEFI handles this with trailing sparks.
+
+## Trailing sparks
+
+The setting is `enableTrailingSparks` — *"Enable secondary spark outputs that fire after the primary (rotaries, twin plug engines)"*.
+
+With it enabled, rusEFI drives a second set of ignition outputs that follow the primary ones. The delay between leading and trailing is not a single number: it comes from a **4 by 4 table** (`TRAILING_SPARK_SIZE` and `TRAILING_SPARK_RPM_SIZE` are both 4 in the firmware), so the split can vary with engine speed.
+
+Note that this is not rotary-only. Any twin-plug engine — some twin-plug piston heads use the same idea — can use the same feature.
+
+Do not confuse this with `twoWireBatchIgnition`, which is a different setting for running individually wired coils in wasted-spark mode. See [Ignition Modes](Ignition-Modes).
+
+The rotary settings live under Controller in TunerStudio:
 
 ![TunerStudio Rotary](Images/TS/TunerStudio_rotary.png){: style="width: 374px; height: 303px;" }
 
 [Rotary - TunerStudio Guide](https://rusefi.com/docs/guide/#menu_Controller_Rotary)
+
+## Fuelling
+
+Nothing about rotary fuelling is special to rusEFI, but two ordinary features come up a lot on these engines:
+
+- Rotaries commonly run **primary and secondary injectors** per rotor, with the secondaries only coming in under load. That is [Staged Injection](Staged-Injection).
+- Injector count adds up quickly — a two-rotor with primaries and secondaries is already four channels, and six-injector setups exist. Check the channel count on the [ECU Comparison](ECU-Comparison) before committing to a board.
+
+## What a real build involves
+
+An open RX-8 knowledge dump, [rusefi/rusefi#3247](https://github.com/rusefi/rusefi/issues/3247), inventories what one Series 1 RX-8 conversion actually needed beyond fuel and spark:
+
+* drive-by-wire throttle — see [Electronic Throttle Body Configuration Guide](Electronic-Throttle-Body-Configuration-Guide)
+* dual ignition timing, as above
+* intake runner solenoids and an auxiliary intake port motor
+* an oil metering stepper — see [Stepper Motor](Stepper-Motor)
+* a six-injector configuration
+
+Some control hardware still needs attention. That issue records the part outstanding at the time of writing: **RX-8 gauge cluster CAN support** is only partial. If you need the factory dash to work, check the current state of the issue before planning. Sending data to a dash generally is covered by [CAN Broadcast for Dashboards and Gauges](CAN-Broadcast-for-Dashboards).
+
+## Related pages
+
+* [Ignition Modes](Ignition-Modes) — how coils are wired and fired
+* [Ignition](Ignition) — timing, dwell and corrections
+* [Staged Injection](Staged-Injection) — primary and secondary injectors
+* [Knock Sensing](knock-sensing)
+* [ECU Comparison](ECU-Comparison) — channel counts per board
+* [Lua Scripting](Lua-Scripting) — for the oddities a rotary swap tends to need
+
+## Technical sources
+
+`enableTrailingSparks` and its quoted description, along with `TRAILING_SPARK_SIZE` and `TRAILING_SPARK_RPM_SIZE`, are from `firmware/integration/rusefi_config.txt` in the [rusEFI firmware](https://github.com/rusefi/rusefi).

--- a/_Sidebar.md
+++ b/_Sidebar.md
@@ -58,6 +58,7 @@
 - [Boost Control](Boost-Control)
 - [Traction Control](Traction-Control)
 - [Transmission Control](Transmission-Control)
+- [Rotary Engines](Rotary)
 
 ### Dash & Connectivity
 

--- a/generator/zensical.toml
+++ b/generator/zensical.toml
@@ -70,7 +70,8 @@ nav = [
     {"Lua Scripting" = "Lua-Scripting.md"},
     {"Digital Dash" = "Digital-Dash.md"},
     {"Multispark" = "Multi-Spark.md"},
-    {"Transmission Control" = "Transmission-Control.md"}
+    {"Transmission Control" = "Transmission-Control.md"},
+    {"Rotary Engines" = "Rotary.md"}
   ]},
   {"ECU Hardware" = [
     {"rusEFI Hardware Overview" = "Hardware.md"},


### PR DESCRIPTION
The Home feature table advertises **Rotary Engines ✓**, and the page behind it was **41 words** — with a single inbound link (that table) and no presence in either navigation.

### What's now on it

**The one thing that actually differs on a rotary**: two plugs per rotor housing, leading and trailing, and the firmware feature that drives them.

`enableTrailingSparks` is quoted verbatim — *"Enable secondary spark outputs that fire after the primary (rotaries, twin plug engines)"* — plus the detail that the leading-to-trailing split comes from a **4 by 4 table**, not a fixed number, since `TRAILING_SPARK_SIZE` and `TRAILING_SPARK_RPM_SIZE` are both 4.

Two clarifications that seemed worth making explicit:

- This isn't rotary-only — twin-plug piston engines use the same feature.
- It's **not** `twoWireBatchIgnition`, which is a different setting for wasted spark on individually wired coils.

**Fuelling** points at [Staged Injection](Staged-Injection), since primary and secondary injectors are common on these engines, and at the ECU Comparison, since injector channel count is what actually decides which board works.

**Issue #3247 is expanded rather than just linked.** That RX-8 knowledge dump inventories what a real conversion needed beyond fuel and spark — drive-by-wire, dual ignition timing, intake runner solenoids, an oil metering stepper, six injectors — and records that **RX-8 gauge cluster CAN support was still only partial**. That last point is the one a prospective RX-8 swapper most needs before planning.

### Navigation

Added under Guides in both `_Sidebar.md` and `generator/zensical.toml`. It had none before.

Every sentence from the original page is kept, including the "some control hardware still needs attention" caveat — folded into the section that now explains what specifically that means.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
