### PR TITLE
docs: give the Kick Start page some substance

### DIFF
--- a/Kick-Start.md
+++ b/Kick-Start.md
@@ -1,3 +1,24 @@
 # Kick Start
 
+Engines started by a kick lever, pull cord or hand crank rather than an electric starter — small motorcycle, kart and generator engines, and some vintage cars.
+
 The rusEFI trigger decoder is optimized for engines with a starter, but see https://rusefi.com/forum/viewtopic.php?p=44340#p44340
+
+That optimisation is the main thing to be aware of. An electric starter turns the engine at a fairly steady speed for as long as you hold the key, which is the situation the decoder is written for. A kick or a pull gives it far less to work with.
+
+## Settings that matter
+
+**Cranking RPM limit.** rusEFI treats anything below this as cranking and applies cranking fuel and ignition instead of the running tables. The [Cranking](Cranking) page describes it as *"the RPM limit below which the ECU will use cranking fuel and ignition logic - typically 350-450 RPM"*. On an engine that is kicked rather than cranked, whether the engine passes that threshold at all — and how quickly — is worth checking before chasing a fuelling problem.
+
+There is also a `kickStartCranking` setting exposed in TunerStudio. It carries no description in the firmware configuration, so what it changes is not documented here rather than guessed at.
+
+## If it will not fire
+
+`KickStart` is cut code 13. If the ECU is refusing to fire and reports that code, see [Error Codes](Error-Codes), and [Cranking](Cranking) for the wider first-start checklist.
+
+## Related pages
+
+* [Cranking](Cranking) — cranking fuel, timing and the RPM threshold
+* [Trigger Configuration Guide](Trigger-Configuration-Guide) — getting the decoder to sync
+* [Error Codes](Error-Codes) — cut codes including `KickStart`
+* [Bench Testing Outputs](Bench-Testing) — confirming spark and fuel before you kick


### PR DESCRIPTION
The Home feature table lists **Kick Start ✓** and the page behind it was **17 words** — one sentence and a forum link, with no inbound link other than that table.

**This one stays deliberately modest, because the topic is genuinely thin.** I went looking for firmware to document and mostly didn't find any, so I'd rather leave it short and honest than pad it.

Your original sentence and forum link are kept word for word. Around them the page now says what a kick-start engine is, why the trigger-decoder note matters — a starter turns the engine steadily for as long as you hold the key, a kick doesn't — and which settings to look at first.

- **Cranking RPM limit**, quoted from the Cranking page. Whether a kicked engine crosses that threshold at all is the first thing to check before chasing a fuelling problem.
- **Cut code 13 `KickStart`**, linked to Error Codes, so someone whose engine refuses to fire can connect the code back here.

### One deliberate gap, and a question

There's a **`kickStartCranking`** setting exposed in TunerStudio. In `rusefi_config.txt` it's just:

```
bit kickStartCranking,"yes","no"
```

No description, and none in the generated headers either. Searching the firmware, I could only find it in `rusefi_config.txt`, the generated Lua lookup, and the ~40 generated per-board structure headers — nothing that reads it. Same for `ClearReason::KickStart`: declared in `limp_manager.h`, but I couldn't find where it gets set.

Code search isn't exhaustive, so **I'm not claiming these do nothing** — I just couldn't establish what they do. The page says the behaviour isn't documented rather than inventing one. If you can say what `kickStartCranking` changes, I'll add it and this becomes a genuinely useful page instead of a placeholder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
