### PR TITLE
docs: add an Engine Protection page

### DIFF
--- a/Engine-Protection.md
+++ b/Engine-Protection.md
@@ -1,0 +1,79 @@
+# Engine Protection
+
+rusEFI can cut fuel, cut spark or hold RPM down when something looks dangerous. This page collects those protections in one place — what each one watches, and what it does when it acts.
+
+None of this replaces a conservative tune. Protection is what catches the case you did not anticipate; it is not permission to lean on a map you have not checked.
+
+## How a protection shows up
+
+Every protection that stops the engine firing reports a **cut code**. That code is the ECU telling you which protection acted, and it is the fastest way to tell "the engine is broken" from "the engine is being protected".
+
+Cut codes are visible in TunerStudio and in logs. The full list is on [Error Codes](Error-Codes); finding them in a log is covered by [Diagnostics and Logging](Diagnostics-and-Logging).
+
+## The protections
+
+### Rev limit
+
+Cut code `HardLimit`. The headline limiter — see [Rev Limiter](Rev-Limiter) for the limit itself and whether it cuts spark, fuel or both.
+
+### Overboost
+
+Cut code `BoostCut`. Cuts when manifold pressure exceeds what you allowed. Configured alongside the rest of boost control — see [Boost Control](Boost-Control).
+
+### Oil pressure
+
+Cut code `OilPressure`. Controlled by `minOilPressureAfterStart`:
+
+> *"Expected oil pressure after starting the engine. If oil pressure does not reach this level within 5 seconds of engine start, fuel will be cut. Set to 0 to disable and always allow starting."*
+
+This is the protection most worth wiring up on any engine you care about, and it needs an [oil pressure sensor](Oil-Pressure-Sensor) to work.
+
+### Lean protection
+
+Cut code `LambdaProtection`. Watches measured lambda and acts if the engine goes lean when it is loaded up — the condition that melts pistons. It needs a working [wideband sensor](Wide-Band-Sensors).
+
+It is deliberately hard to trigger by accident. The settings form three groups:
+
+| Setting group | Purpose |
+|---|---|
+| `lambdaProtectionEnable` | Turns the whole feature on |
+| `lambdaProtectionMinRpm`, `lambdaProtectionMinLoad`, `lambdaProtectionMinTps` | Arm it only above these — lean at idle or on overrun is not the dangerous case |
+| `lambdaProtectionThreshold` | How lean is too lean |
+| `lambdaProtectionTimeout` | *"Only respond once lambda is out of range for this period of time. Use to avoid transients triggering lambda protection when not needed"* |
+| `lambdaProtectionRestoreRpm`, `lambdaProtectionRestoreLoad`, `lambdaProtectionRestoreTps` | Conditions for coming back out of protection |
+
+The timeout matters. A momentary lean spike during a fast transient is normal; sustained lean under load is not, and the timeout is what separates the two.
+
+### Injector duty cycle
+
+Cut code `InjectorDutyCycle`. Injectors that never close cannot deliver more fuel, and an engine asking for more than the injectors can flow will go lean at the worst moment. There are two levels: `injectorDutyCycleWarning` raises a warning, and `injectorDutyCycleCritical` is where the engine is stopped.
+
+If you are hitting these, the injectors are undersized for what the engine is now asking for — see [Fuel Overview](Fuel-Overview).
+
+### Electronic throttle jam
+
+Cut code `EtbJammedRevLimit`, described in firmware as *"means 1500 RPM limit in ETB jam was detected"*. Rather than cutting out entirely, rusEFI holds the engine to a low RPM so a jammed throttle cannot run away with the car. A separate `EtbProblem` cut code covers other throttle faults — see [Electronic Throttle Body Configuration Guide](Electronic-Throttle-Body-Configuration-Guide).
+
+### After a fatal error
+
+Cut code `FatalErrorRevLimit`. A reduced RPM limit imposed after a firmware fatal error, so a controller that has already failed once cannot be revved hard.
+
+### Knock
+
+Knock is handled differently — instead of cutting, rusEFI retards timing and then restores it. That makes it a continuous correction rather than an on/off protection, so it has no cut code of its own. See [Knock Sensing](knock-sensing).
+
+## Other cuts that are not protections
+
+Several cut codes exist that are working as intended rather than protecting anything: `LaunchCut` for [launch control](HOWTO-Launch-Control), `FloodClear` while clearing a flooded engine, `IgnitionOff`, `Lua` when a script requests a cut, and `EnginePhase` when the ECU has not worked out crank position yet. Do not chase these as faults. [Error Codes](Error-Codes) lists all of them.
+
+## Related pages
+
+* [Error Codes](Error-Codes) — every cut code and what it means
+* [Diagnostics and Logging](Diagnostics-and-Logging) — finding a cut in a log
+* [Troubleshooting](Troubleshooting) — symptom-first help
+* [Rev Limiter](Rev-Limiter), [Boost Control](Boost-Control), [Oil Pressure Sensor](Oil-Pressure-Sensor), [Knock Sensing](knock-sensing)
+* [Ignition](Ignition) — why excessive advance is the underlying risk behind several of these
+
+## Technical sources
+
+Cut code names are the `ClearReason` enumeration in [`firmware/controllers/limp_manager.h`](https://github.com/rusefi/rusefi/blob/master/firmware/controllers/limp_manager.h). Setting names and the quoted descriptions come from `firmware/integration/rusefi_config.txt` and the generated configuration headers in the same repository.

--- a/Error-Codes.md
+++ b/Error-Codes.md
@@ -4,6 +4,8 @@ If the engine will not fire, rusEFI usually knows why and is telling you. The **
 
 Cut codes and ETB codes are visible in TunerStudio and in your logs. See [Diagnostics and Logging](Diagnostics-and-Logging) for where to find them, and [Troubleshooting](Troubleshooting) for symptom-based help.
 
+If the code turns out to be a protection doing its job, [Engine Protection](Engine-Protection) explains what each one watches and how it is configured.
+
 ## Cut codes
 
 A non-zero cut code means the ECU has deliberately stopped fuel, spark or both. `None` (0) means nothing is being cut.

--- a/Troubleshooting.md
+++ b/Troubleshooting.md
@@ -40,6 +40,7 @@ It helps to have rusEFI Console and/or TunerStudio connected first, so you can r
 ## Error codes and warnings
 
 - [rusEFI Error Codes](Error-Codes) - OBD codes, cut codes, and ETB error codes.
+- [Engine Protection](Engine-Protection) - if the ECU is cutting deliberately, this explains which protection acted and why.
 - [LED states](LED-states) - LED meanings, including the [fatal error](LED-states#fatal-error) state.
 
 ## CAN and external devices

--- a/_Sidebar.md
+++ b/_Sidebar.md
@@ -20,6 +20,7 @@
 - [Troubleshooting](Troubleshooting)
 - [Diagnostics & Logging](Diagnostics-and-Logging)
 - [Logging](Logging-Guide)
+- [Engine Protection](Engine-Protection)
 
 ### Wiring, Sensors & Calibration
 

--- a/generator/zensical.toml
+++ b/generator/zensical.toml
@@ -56,6 +56,7 @@ nav = [
   {"Guides" = [
     {"Wiring & Connectivity Overview" = "FAQ-Basic-Wiring-and-Connections.md"},
     {"Bench Testing Outputs" = "Bench-Testing.md"},
+    {"Engine Protection" = "Engine-Protection.md"},
     {"Cranking" = "Cranking.md"},
     {"Trigger - Configuration" = "Trigger-Configuration-Guide.md"},
     {"Trigger - Setting Offset" = "How-Do-I-Set-My-Trigger-Offset.md"},


### PR DESCRIPTION
rusEFI has at least eight distinct protections that cut fuel, cut spark or hold RPM down, and there was no page about them as a group.

**Two of them appear nowhere in the wiki at all** except as one-line rows in the cut code table: **lean protection** and the **injector duty cycle limit**. Both exist to stop an engine destroying itself.

### What's on the page

Rev limit · overboost · oil pressure · lean protection · injector duty cycle · electronic throttle jam · reduced limit after a fatal error · knock (which is different — it retards timing rather than cutting, so it has no cut code).

It leads with the practical point: **every protection reports a cut code**, so the code tells you whether the engine is broken or being protected. That distinction is the whole value of the page when something won't fire.

It also separates out the cuts that **aren't** protections — `LaunchCut`, `FloodClear`, `IgnitionOff`, `Lua`, `EnginePhase` — so nobody chases those as faults.

### On sourcing, since I was burned earlier this week

Two firmware descriptions are quoted verbatim, and I **confirmed each in two separate files** before using them:

- `minOilPressureAfterStart` — *"Expected oil pressure after starting the engine. If oil pressure does not reach this level within 5 seconds of engine start, fuel will be cut. Set to 0 to disable and always allow starting."*
- `lambdaProtectionTimeout` — *"Only respond once lambda is out of range for this period of time. Use to avoid transients triggering lambda protection when not needed"*

The remaining settings — `lambdaProtectionThreshold`, `injectorDutyCycleWarning`, `injectorDutyCycleCritical` and the lambda min/restore groups — are **named without quoting their descriptions**. `rusefi_config.txt` is large enough that fetches truncate differently each time, and I couldn't double-source those, so I described behaviour from the field names and the verified cut codes instead of quoting something I couldn't confirm.

If you want those descriptions quoted too, they're presumably accurate in the config — I just wouldn't put them in quotation marks without checking.

### Links

From Troubleshooting under error codes, from Error Codes itself, and added to Troubleshooting & Diagnostics in both navigations.

All 13 cut codes named on the page cross-check against the Error Codes table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
