### PR TITLE
docs: explain the firmware version choice properly

### DIFF
--- a/Release-Snapshot-Latest-firmware.md
+++ b/Release-Snapshot-Latest-firmware.md
@@ -1,5 +1,9 @@
 # Firmware Versions
 
+Every board page offers the firmware two ways — a Release bundle, or the Universal Updater with a beta snapshot. This page is what those choices mean.
+
+**If you are not sure, take the Release.** Snapshots exist for people who need a change that has not been released yet, or who are helping test one.
+
 ## Release
 
 The firmware version that has been more thoroughly tested.
@@ -11,3 +15,37 @@ Potentially less stable version with all the most recent changes, sometimes know
 ## Latest
 
 "latest" is a bad term since it could be either "latest release" or "latest snapshot".
+
+## Where each one comes from
+
+There are three places builds appear, and they are not the same thing:
+
+| Build | Where | Notes |
+|---|---|---|
+| Release | The board's own page, or [Download](Download) | The tested build. This is the default choice |
+| Nightly / pre-release | [GitHub releases marked pre-release](https://github.com/rusefi/rusefi/releases?q=prerelease%3Atrue) | Automatic builds published as GitHub pre-releases |
+| Snapshot | [rusEFI build server](https://rusefi.com/build_server/) | The most recent build of all. Per [Download](Download), a snapshot takes roughly 30 minutes to appear after a change |
+
+[Older releases](https://github.com/rusefi/rusefi/releases?q=prerelease%3Afalse) are also kept, which is what you want if you need to go back to a version that worked.
+
+## The Universal Updater
+
+Board pages offer `rusEFI_Universal_Updater` as the route to a beta snapshot. It is a Windows installer, downloaded from `rusefi.com/installer`, rather than a bundle zip you unpack yourself.
+
+Its detailed behaviour is not documented on this wiki. If you want to know exactly what it does before running it, ask on the [forum](https://rusefi.com/forum/) or [Discord](Discord) rather than assuming it matches the manual bundle route.
+
+## Which one should I be on?
+
+- **Building or troubleshooting an engine** — stay on Release. Debugging a no-start is hard enough without an unfamiliar firmware in the mix.
+- **You have been told a fix is in a recent commit** — a snapshot is the point. Note which build you took, so you can say what you are running when reporting back.
+- **Testing or contributing** — snapshots are what you want, and reporting problems against them is genuinely useful.
+
+Whichever you take, the bundle contains more than firmware. See [rusEFI Bundle](rusEFI-bundle) for what is inside it, and [HOWTO Update Firmware](HOWTO-Update-Firmware) for flashing.
+
+## Related pages
+
+* [Download](Download) — bundles for each board
+* [HOWTO Update Firmware](HOWTO-Update-Firmware) — flashing a bundle
+* [HOWTO DFU](HOWTO-DFU) — recovery flashing when normal updating will not work
+* [rusEFI Bundle](rusEFI-bundle) — what the bundle contains
+* [Virtual Simulator](Virtual-simulator) — trying firmware without hardware


### PR DESCRIPTION
Every board page presents the firmware two ways:

```
[📦 Release Software]
[🆕 rusEFI_Universal_Updater with Beta Snapshot 🆕]
[ℹ️ Release vs Snapshot ℹ️]   ← this page
```

The page people click to decide was **48 words** and **never mentioned the Universal Updater** — so it didn't cover one of the two options it exists to explain.

It's linked from **ten pages**, including every universal board page, which makes it one of the more travelled pages on the wiki.

### All three original definitions are kept word for word

Added around them:

- **A recommendation.** Take the Release unless you need a change that hasn't been released yet. The page described the options without ever suggesting one.
- **Where builds actually come from.** `Download` links three genuinely different things — Release, GitHub pre-release nightlies, and build-server snapshots — and this page now distinguishes them, including Download's own note that a snapshot takes ~30 minutes to appear.
- **Older releases**, since rolling back to a version that worked is a normal thing to need.
- **What the Universal Updater is** — a Windows installer from `rusefi.com/installer` rather than a bundle zip.
- **Which version suits which situation** — building or troubleshooting, chasing a specific fix, or testing.

### One deliberate gap

**The Universal Updater's detailed behaviour isn't documented anywhere on the wiki.** I could see what it is and where it comes from, but not what it actually does when you run it — whether it detects the board, what it replaces, whether it touches TunerStudio.

Rather than guess, the page says the behaviour isn't documented and points at the forum. If you tell me what it does, that turns into a proper section — and it's arguably the piece most worth having, since it's the route offered on every board page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
