### PR TITLE
docs: cover the missing sensors in the Sensors and Calibration hub

### DIFF
--- a/Sensors-and-Calibration.md
+++ b/Sensors-and-Calibration.md
@@ -7,6 +7,7 @@ For sensor wiring specifics, see the [Wiring & Connectivity Overview](FAQ-Basic-
 ## Temperature
 
 - [Coolant and Intake Air Temperature (CLT/IAT)](Temperature-Sensors) — thermistor bias resistor and three-point calibration.
+- [Temperature Sensing](Temperature-Sensing) — the `analoginfo` and `tempinfo` console commands for checking what the ECU is actually reading.
 
 ## Pressure
 
@@ -14,14 +15,23 @@ For sensor wiring specifics, see the [Wiring & Connectivity Overview](FAQ-Basic-
 - [Oil Pressure (and linear analog sensors)](Oil-Pressure-Sensor) — two-point voltage-to-pressure calibration, also used for fuel pressure and other linear sensors.
 - [Fuel Pressure](Fuel-Pressure) — low-side and high-pressure (GDI) fuel sensors, and why fuel pressure matters for injector flow.
 
+## Air flow
+
+- [Mass Air Flow (MAF)](MAF) — measuring intake air mass directly, as an alternative to calculating it from manifold pressure.
+
 ## Throttle
 
 - [Throttle Position and Pedal (TPS/APP)](Throttle-and-Pedal-Sensors) — closed / wide-open calibration and drive-by-wire pedal redundancy.
+- [SENT throttle and pedal sensors](SENT-ETB-Electronic-Throttle-Body) — digital SENT-protocol sensors rather than analog voltage.
 
 ## Air/fuel ratio (oxygen)
 
 - [Wideband Oxygen Sensors](Wide-Band-Sensors) — wideband / lambda AFR measurement.
 - [Medium Band Oxygen Sensor](Medium-band-oxygen) — Denso two-wire sensor.
+
+## Fuel composition
+
+- [Flex Fuel](Flex-Fuel) — ethanol content sensor, and the corrections that depend on it.
 
 ## Position and combustion
 

--- a/Temperature-Sensors.md
+++ b/Temperature-Sensors.md
@@ -30,6 +30,7 @@ Choose three points spread across the operating range (for example cold, warm, a
 
 ## Related pages
 
+- [Temperature Sensing](Temperature-Sensing) — the `analoginfo` and `tempinfo` console commands, for checking the voltage and resistance rusEFI is actually seeing.
 - [Wiring & Connectivity Overview](FAQ-Basic-Wiring-and-Connections) — sensor wiring and grounds.
 - [Vault of Sensors](Vault-Of-Sensors) — tested sensors and their values.
 


### PR DESCRIPTION
`Sensors-and-Calibration` is a well-organised hub, but four sensor pages weren't reachable from it — including the largest one.

| Added | Size | Where |
|---|---|---|
| **Mass Air Flow** | 752w | New **Air flow** heading |
| **SENT throttle and pedal sensors** | 169w | Under Throttle |
| **Flex Fuel** | 344w | New **Fuel composition** heading |
| **Temperature Sensing** | 132w | Next to Temperature Sensors |

**MAF is the notable one.** It had no entry at all, despite being 752 words and one of the two ways rusEFI can determine engine load. A sensor hub that omits mass airflow has a real hole in it.

### The two temperature pages

`Temperature-Sensing` and `Temperature-Sensors` overlap — both cover thermistor CLT/IAT setup. I linked both rather than picking one, because the older page **uniquely documents the `analoginfo` and `tempinfo` console commands**, which are how you see the voltage and resistance rusEFI is actually reading. `Temperature-Sensors` mentions neither, so it now links across too.

**Worth a decision at some point:** those two probably want merging, with the console commands folded into the newer page. I didn't do it because deleting or merging a page is a content call rather than a linking one. Happy to do it if you say which way.

No content is rewritten — these are link entries with one-line descriptions in the style the hub already uses.

One thing deliberately left out: the hub doesn't cover load-sensing *strategy* (speed density vs alpha-N vs MAF), since that's `Fuel-Overview`'s job. Say if you'd rather it pointed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
