### PR TITLE
docs: surface the carburettor to EFI conversion guide

### DIFF
--- a/Getting-Started.md
+++ b/Getting-Started.md
@@ -13,7 +13,9 @@ Decide which ECU suits your engine and the features you need. rusEFI runs on two
 - **Universal ECUs** — you wire them to your engine yourself.
 - **Plug-and-play (PnP) ECUs** — they connect to a specific factory harness.
 
-See the [Hardware overview](Hardware) for the supported boards, and [Other Hardware](Other-Hardware) for additional options. You can also design your own board.
+See the [Hardware overview](Hardware) for the supported boards, the [ECU Comparison](ECU-Comparison) for a spec-by-spec table, and [Other Hardware](Other-Hardware) for additional options. You can also design your own board.
+
+> Running a carburettor? The engine needs injection hardware before an ECU is any use — see [Converting an Engine to Fuel Injection](how-to-convert-from-carburetor-to-EFI) for what that involves.
 
 ## 2. Get the software
 

--- a/_Sidebar.md
+++ b/_Sidebar.md
@@ -38,6 +38,7 @@
 ### Fuel
 
 - [Fueling](Fuel-Overview)
+- [Converting from a Carburettor](how-to-convert-from-carburetor-to-EFI)
 - [Flex Fuel](Flex-Fuel)
 - [Direct Injection](GDI-status)
 

--- a/generator/zensical.toml
+++ b/generator/zensical.toml
@@ -63,6 +63,7 @@ nav = [
     {"Logging" = "Logging-Guide.md"},
     {"Wideband Oxygen Sensors" = "Wide-Band-Sensors.md"},
     {"Fueling" = "Fuel-Overview.md"},
+    {"Converting from a Carburettor" = "how-to-convert-from-carburetor-to-EFI.md"},
     {"Flex Fuel" = "Flex-Fuel.md"},
     {"Direct Injection" = "GDI-status.md"},
     {"Knock Sensing" = "knock-sensing.md"},

--- a/how-to-convert-from-carburetor-to-EFI.md
+++ b/how-to-convert-from-carburetor-to-EFI.md
@@ -2,7 +2,7 @@
 
 *If there is an OEM EFI solution for your engine, you should probably start there.*
 
-If no such system exists or is prohibitively expensive, or if you just love punishmen, read on.
+If no such system exists or is prohibitively expensive, or if you just love punishment, read on.
 
 ## Requirements
 


### PR DESCRIPTION
**"Converting an Engine to (port) Fuel Injection"** is a 702-word hardware checklist — intake manifold, throttle body, fuel pump, injectors, fuel rail, O2 sensor, trigger signal, engine management, other sensors.

It had **one inbound link** (the Fuel index) and was in **neither navigation**.

That's a page answering a question people arrive with *before* they get as far as choosing an ECU: can my carburetted engine run rusEFI at all, and what does that take? `Getting-Started`, `Home` and `Quick Start` never mentioned it.

### Changes

- Added to the **Fuel** section of both navigations.
- Added a note to **step 1 of the Getting Started roadmap**, where choosing hardware is discussed — the engine needs injection hardware before an ECU is any use.
- Step 1 now also points at the **ECU Comparison** alongside the Hardware overview, which it should have done when that page landed.
- Fixed a typo on the page: *"if you just love punishmen"* → *"punishment"*.

Found by auditing for substantial pages with almost no inbound links. Most of the other hits were vehicle pages, which I've left alone per #730.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
