### PR TITLE
docs: give the CAN Bus page an orientation section and put it in the nav

### DIFF
--- a/CAN.md
+++ b/CAN.md
@@ -1,5 +1,22 @@
 # CAN Bus
 
+CAN is the wiring most rusEFI features use to talk to anything that is not the engine itself — dashboards, wideband controllers, transmission controllers, and in several cases the tuning laptop. It is two wires, and once it is run, several features share it because they use different message IDs.
+
+## What CAN is used for
+
+| I want to | Page |
+|---|---|
+| Show engine data on a dash or gauge cluster | [CAN Broadcast for Dashboards and Gauges](CAN-Broadcast-for-Dashboards) |
+| Connect TunerStudio over CAN instead of USB | [TunerStudio over CAN](TS-over-CAN) |
+| Tune or log wirelessly | [CANbus to WiFi adapter](can2wifi) |
+| Read a wideband oxygen sensor | [rusEFI Wideband Controller](rusEFI-Wideband-Controller) |
+| Run a factory automatic transmission | [Transmission Control](Transmission-Control) |
+| Drive GDI injectors through an external module | [GDI status](GDI-status) |
+| Change calibrations over CAN | [Calibration via CAN](rusEFI-calibration-via-CAN) |
+| Flash firmware over CAN | [Firmware Update via CAN](Firmware-update-via-CAN) |
+
+Wiring, termination and bus speed are covered on [CAN Broadcast for Dashboards and Gauges](CAN-Broadcast-for-Dashboards) — a CAN bus needs a 120 ohm terminator at each end, and both ends must agree on speed. For everything else on the communications side, see the [communications index](Pages-Communications).
+
 ## Overview of CAN usage and IDs used by rusEFI
 
 Note: We support OBD2 pretty much exclusively for gauges/dashes/apps/etc, not real diagnosis!

--- a/_Sidebar.md
+++ b/_Sidebar.md
@@ -68,6 +68,7 @@
 ### Dash & Connectivity
 
 - [Lua Scripting](Lua-Scripting)
+- [CAN Bus](CAN)
 - [Digital Dash](Digital-Dash)
 - [Bluetooth](Bluetooth)
 

--- a/generator/zensical.toml
+++ b/generator/zensical.toml
@@ -85,6 +85,7 @@ nav = [
     {"Transmission Control" = "Transmission-Control.md"},
     {"Rotary Engines" = "Rotary.md"},
     {"Lua Scripting" = "Lua-Scripting.md"},
+    {"CAN Bus" = "CAN.md"},
     {"Digital Dash" = "Digital-Dash.md"},
     {"Bluetooth" = "Bluetooth.md"},
     {"Multispark" = "Multi-Spark.md"}


### PR DESCRIPTION
CAN is how rusEFI talks to almost everything that isn't the engine — dashboards, wideband controllers, transmission controllers, and in several cases the tuning laptop.

The page opened with the heading *"Overview of CAN usage and IDs used by rusEFI"* and then went straight into a list of hex addresses. That's a **reference sheet, not an overview** — and it was in **neither navigation**.

### Added

A short lead, and a table answering the question people actually arrive with:

| I want to | Page |
|---|---|
| Show engine data on a dash | CAN Broadcast for Dashboards |
| Connect TunerStudio over CAN | TS-over-CAN |
| Tune or log wirelessly | can2wifi |
| Read a wideband | rusEFI Wideband Controller |
| Run a factory automatic | Transmission Control |
| Drive GDI injectors | GDI status |
| Change calibrations over CAN | Calibration via CAN |
| Flash firmware over CAN | Firmware Update via CAN |

**All of those pages already existed — nothing pointed at them from here.** The CAN page listed the message IDs for several of these features without saying what the features were.

It also now notes where wiring, termination and bus speed are covered, since that's the first thing that goes wrong and it currently lives on the dashboard broadcast page rather than here.

### Preserved

Everything already on the page: the full CAN ID list, the OpenBLT commands, the hardware options, the forum links, both screenshots.

Added to **Dash & Connectivity** in both navigations, and I re-checked that the two navs are still fully in sync afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
