### PR TITLE
docs: link pages that discuss a topic to the page about it

### DIFF
--- a/ECU-Comparison.md
+++ b/ECU-Comparison.md
@@ -28,7 +28,7 @@ For prices, store links and a short description of each board, see the [Hardware
 | VR (crank / cam) | 1 | 2 | 2 | 2 | 3 | **none** ƒ | 2 | 1, VR or Hall |
 | Hall / digital | — | 3 | 3 ƒ | 3 ƒ | 5 | 1 ƒ | 6 | 1 |
 | Analog inputs | 5 | 9 + 2 | 7 + 2 | 7 + 2 | 13 + 2 temp | 6 ƒ | 11 + 4 temp | 10 + 4 thermistor |
-| Knock sensing | — | yes | yes | yes | dual channel | yes ƒ | yes | — |
+| [Knock sensing](knock-sensing) | — | yes | yes | yes | dual channel | yes ƒ | yes | — |
 | Flex fuel input | — | yes | — | — | — | — | — | — |
 
 ## Outputs
@@ -37,7 +37,7 @@ For prices, store links and a short description of each board, see the [Hardware
 |---|---|---|---|---|---|---|---|---|
 | Low-side drivers | 6 total | 4 above 1 A, 6 on newer | 6 additional | 6 additional | 35 ƒ | 4 | 16 x 4 A | 2 high-current, 4 low-current |
 | High-side drivers | — | — | 1 x 2 A | 1 x 2 A | — | — | 4 x 12 V 3 A | — |
-| Electronic throttle (DBW) | — | 2 x 6 A H-bridge | dual | dual | 4 H-bridges | 1 DC output ƒ | dual | single |
+| [Electronic throttle (DBW)](Electronic-Throttle-Body-Configuration-Guide) | — | 2 x 6 A H-bridge | dual | dual | 4 H-bridges | 1 DC output ƒ | dual | single |
 | Stepper idle valve | — | yes | yes ƒ | yes ƒ | yes ƒ | — ƒ | yes | yes ƒ |
 | Tachometer output | dedicated pin | configurable | configurable | configurable | configurable | configurable | configurable | configurable |
 

--- a/FAQ-Basic-Wiring-and-Connections.md
+++ b/FAQ-Basic-Wiring-and-Connections.md
@@ -143,7 +143,7 @@ Aftermarket trigger wheels ("Optical Disc") are available if you plan on install
 
 ### Knock Sensors
 
-Some ECU variants have a provision for knock sensors.
+Some ECU variants have a provision for knock sensors. For what rusEFI does with the signal once it is wired, see [Knock Sensing](knock-sensing).
 
 In regards to Knock Sensor quality of signal, a shielded cable (2 core) is recommended.
 

--- a/Fuel-Overview.md
+++ b/Fuel-Overview.md
@@ -18,7 +18,7 @@ rusEFI supports mono, individual/sequential and batched fuel injection using one
 
 4. [MAF](MAF)-based air charge model that computes the air mass in the cylinder and thus the required fuel quantity from the direct measurement of the mass air flow.
 
-Wideband Oxygen Sensor is pretty much a requirement for both manual and auto-tuning.
+A [Wideband Oxygen Sensor](Wide-Band-Sensors) is pretty much a requirement for both manual and auto-tuning.
 
 ![General Settings](Images/Fuel_Control/general.png)
 

--- a/HOWTO-Make-Your-Own-ECU-Communicate-with-TCU.md
+++ b/HOWTO-Make-Your-Own-ECU-Communicate-with-TCU.md
@@ -1,5 +1,7 @@
 # HOWTO Make Your Own ECU Communicate with TCU
 
+For an overview of the available approaches — rusEFI's own TCU logic, the Purple Gateway, or doing the CAN work yourself as described here — see [Transmission Control](Transmission-Control).
+
 ## Summary
 
 Notes on PG35 TCU Man-in-the-middle research.

--- a/HOWTO-TCU-A42DE-on-Proteus.md
+++ b/HOWTO-TCU-A42DE-on-Proteus.md
@@ -1,5 +1,7 @@
 # How to TCU A42DE on Proteus
 
+See [Transmission Control](Transmission-Control) for which approach suits which gearbox; this page covers driving an older solenoid-controlled unit directly.
+
 [Proteus 0.2](Hardware-Proteus-Wiring-v02)
 
 [Mazda Miata 2001](Mazda-Miata-2001)


### PR DESCRIPTION
Since the CAN page landed well, I built a detector for the same pattern: **pages that mention a subject repeatedly and never link the page covering it.**

Six links, no content rewritten.

| Page | Discusses | Times | Linked? |
|---|---|---|---|
| HOWTO Make Your Own ECU Communicate with TCU | Transmission Control | **22** | no |
| How to TCU A42DE on Proteus | Transmission Control | 4 | no |
| Wiring & Connectivity Overview | Knock Sensing | 4 | no |
| Fuel Overview | Wide Band Sensors | 2 | no |
| ECU Comparison | Knock Sensing, ETB | 4, 2 | no |

The first is the striking one — **22 mentions of transmission control with no link to the hub.** The hub links *to* it; the link back was missing.

A couple of specifics:

- **Wiring & Connectivity Overview** has a whole `### Knock Sensors` section on wiring the sensor, with nothing pointing at what rusEFI does with the signal once it's connected.
- **Fuel Overview** states a wideband sensor *"is pretty much a requirement for both manual and auto-tuning"* — a strong claim with no link to the page about them.
- **ECU Comparison** linked its Wideband controller row but not Knock sensing or Electronic throttle. That's my own inconsistency from when I wrote it.

### Deliberately not changed

`HOWTO-Get-Running` mentions the electronic throttle without linking the configuration guide — but it links `Electronic-Throttle-Body`, which links the guide twice. The route already exists, so adding another would be noise.

Vehicle pages showed up in the same scan and are left alone per #730.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
