### PR TITLE
docs: fix the last two hand-maintained link defects

### DIFF
--- a/Mazda-Miata-2002.md
+++ b/Mazda-Miata-2002.md
@@ -12,7 +12,7 @@
 
 ![Wiring Diagram](Images/diagrams/Mazda_miata_2002_instrument.png)
 
-## Starting & power
+## Starting and power
 
 Main relay is controlled by ignition switch (this is different from 2003 where ECU controls main relay via 3H).
 

--- a/Mazda-Miata-2003.md
+++ b/Mazda-Miata-2003.md
@@ -4,7 +4,7 @@
 
 See also [Mazda Miata 2003 alt](Mazda-Miata-2003-alt)
 
-For power see [Mazda Miata 2002 - Starting & Power](Mazda-Miata-2002#starting-power)
+For power see [Mazda Miata 2002 - Starting and power](Mazda-Miata-2002#starting-and-power)
 
 ![Connector Face](Images/diagrams/NB2_Miata_ECU_Connectors_Drawing_rusEFI_harness.png)
 
@@ -73,7 +73,7 @@ Fly-back diode - stripe facing +12 - is needed between IAC 2P (power, stripe sid
 
 See [http://rusefi.com/forum/viewtopic.php?f=3&t=906&p=25018l#p25018](http://rusefi.com/forum/viewtopic.php?f=3&t=906&p=25018l#p25018)
 
-For ignition key see [Mazda Miata 2002 - Starting & Power](Mazda-Miata-2002#starting-power)
+For ignition key see [Mazda Miata 2002 - Starting and power](Mazda-Miata-2002#starting-and-power)
 
 ## Misc
 

--- a/OEM-connectors.md
+++ b/OEM-connectors.md
@@ -1,4 +1,3 @@
-
 # OEM Connectors
 
 ## Table of Contents

--- a/Online.md
+++ b/Online.md
@@ -1,4 +1,3 @@
-
 # rusEFI Online
 
 [rusEFI Online](https://rusefi.com/online/) is facilitating data flow within rusEFI open source engine management community.


### PR DESCRIPTION
Two things I'd been carrying as known-but-unfixed.

### The Miata anchor, properly this time

`Mazda-Miata-2003` links twice into `Mazda-Miata-2002` at `#starting-power`. The heading there was **`## Starting & power`**, and the two renderers disagree about what that becomes:

| Renderer | Slug |
|---|---|
| GitHub wiki | `starting--power` (doesn't collapse the gap left by `&`) |
| zensical / python-markdown | `starting-power` |

So the link **worked on wiki.rusefi.com and was broken on the GitHub mirror**. I deliberately left it earlier rather than "fix" a link that worked on the main site — changing it to the GitHub form would have broken the one that mattered more.

Rewording the heading to **`Starting and power`** removes the ambiguity entirely: both renderers now produce `starting-and-power`. Both links updated to match.

Checked first that nothing else links that anchor, and that no other heading in the wiki has the same double-hyphen problem.

### Stray blank first lines

`OEM-connectors` and `Online` began with a blank line before their title. Both now start with their heading like every other page.

### Result

The whole-wiki scan now reports **zero link defects outside `All-Supported-Triggers`**, whose remaining 13 dead in-page anchors and one missing image are items 2 and 4 of #719 — those need someone who knows the triggers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
