### PR TITLE
docs: surface the Proteus F767 programming instructions

### DIFF
--- a/F7-requires-full-erase.md
+++ b/F7-requires-full-erase.md
@@ -23,3 +23,4 @@ While most rusEFI units support incremental firmware update while keeping settin
 - [HOWTO Flash using STM32CubeProgrammer](HOWTO-flash-using-Stm32CubeProgrammer) - advanced / last-resort flashing via STM32CubeProgrammer (DFU or ST-Link).
 - [Hardware Validation Failed](HARDWARE-VALIDATION-FAILED) - diagnosing the "HARDWARE VALIDATION FAILED" startup error.
 - [4chan F7 Initial Programming](4chan-F7-initial-programming) - one-time initial programming for AlphaX 4chan F7 boards.
+- [Proteus F767 Programming Instructions](Proteus-F767-programming-instructions) - DFU + STM32CubeProgrammer procedure for Proteus 0.6 boards with the F767 chip.

--- a/HARDWARE-VALIDATION-FAILED.md
+++ b/HARDWARE-VALIDATION-FAILED.md
@@ -11,3 +11,4 @@ Whatever is the root cause of the issue it's outside of rusEFI firmware control.
 - [HOWTO Flash using STM32CubeProgrammer](HOWTO-flash-using-Stm32CubeProgrammer) - advanced / last-resort flashing via STM32CubeProgrammer (DFU or ST-Link).
 - [F7 Requires Full Erase](F7-requires-full-erase) - some F7 Proteus units require a full erase before a firmware update.
 - [4chan F7 Initial Programming](4chan-F7-initial-programming) - one-time initial programming for AlphaX 4chan F7 boards.
+- [Proteus F767 Programming Instructions](Proteus-F767-programming-instructions) - DFU + STM32CubeProgrammer procedure for Proteus 0.6 boards with the F767 chip.

--- a/HOWTO-DFU.md
+++ b/HOWTO-DFU.md
@@ -41,3 +41,4 @@ A: See https://github.com/rusefi/rusefi/blob/master/firmware/hw_layer/ports/stm3
 - [F7 Requires Full Erase](F7-requires-full-erase) - some F7 Proteus units require a full erase before a firmware update.
 - [Hardware Validation Failed](HARDWARE-VALIDATION-FAILED) - diagnosing the "HARDWARE VALIDATION FAILED" startup error.
 - [4chan F7 Initial Programming](4chan-F7-initial-programming) - one-time initial programming for AlphaX 4chan F7 boards.
+- [Proteus F767 Programming Instructions](Proteus-F767-programming-instructions) - DFU + STM32CubeProgrammer procedure for Proteus 0.6 boards with the F767 chip.

--- a/HOWTO-Update-Firmware.md
+++ b/HOWTO-Update-Firmware.md
@@ -89,3 +89,4 @@ If you chose to do it manually, you can find the .ini file in the USB storage de
 - [F7 Requires Full Erase](F7-requires-full-erase) - some F7 Proteus units require a full erase before a firmware update.
 - [Hardware Validation Failed](HARDWARE-VALIDATION-FAILED) - diagnosing the "HARDWARE VALIDATION FAILED" startup error.
 - [4chan F7 Initial Programming](4chan-F7-initial-programming) - one-time initial programming for AlphaX 4chan F7 boards.
+- [Proteus F767 Programming Instructions](Proteus-F767-programming-instructions) - DFU + STM32CubeProgrammer procedure for Proteus 0.6 boards with the F767 chip.

--- a/HOWTO-flash-using-Stm32CubeProgrammer.md
+++ b/HOWTO-flash-using-Stm32CubeProgrammer.md
@@ -21,3 +21,4 @@ See also [HOWTO-nDBANK](HOWTO-nDBANK)
 - [F7 Requires Full Erase](F7-requires-full-erase) - some F7 Proteus units require a full erase before a firmware update.
 - [Hardware Validation Failed](HARDWARE-VALIDATION-FAILED) - diagnosing the "HARDWARE VALIDATION FAILED" startup error.
 - [4chan F7 Initial Programming](4chan-F7-initial-programming) - one-time initial programming for AlphaX 4chan F7 boards.
+- [Proteus F767 Programming Instructions](Proteus-F767-programming-instructions) - DFU + STM32CubeProgrammer procedure for Proteus 0.6 boards with the F767 chip.

--- a/Proteus-F767-programming-instructions.md
+++ b/Proteus-F767-programming-instructions.md
@@ -55,3 +55,13 @@ Done!
 8. Program as shown in this picture:
 
    ![x](Images/program-using-STM32CubeProgrammer.png)
+
+## Related pages
+
+- [Proteus Manual](Proteus-Manual) - the Proteus board manual, including which revision uses which chip.
+- [How to Update Firmware](HOWTO-Update-Firmware) - main firmware update procedure (Windows and Linux, OpenBLT and DFU).
+- [HOWTO DFU](HOWTO-DFU) - DFU (Device Firmware Update) mode: auto vs. manual, drivers, and troubleshooting.
+- [HOWTO Flash using STM32CubeProgrammer](HOWTO-flash-using-Stm32CubeProgrammer) - advanced / last-resort flashing via STM32CubeProgrammer (DFU or ST-Link).
+- [How to nDBANK](HOWTO-nDBANK) - resetting the nDBANK option byte on F7 chips.
+- [F7 Requires Full Erase](F7-requires-full-erase) - some F7 Proteus units require a full erase before a firmware update.
+- [4chan F7 Initial Programming](4chan-F7-initial-programming) - one-time initial programming for AlphaX 4chan F7 boards.

--- a/Proteus-Manual.md
+++ b/Proteus-Manual.md
@@ -33,6 +33,8 @@ New to rusEFI? [Start here](Home).
 
 Legacy Proteus 0.3-0.5 and 0.7 (STM32F4) [📦Release F4](https://github.com/rusefi/rusefi/releases/latest/download/rusefi_bundle_proteus_f4.zip) [🧪Snapshot F4](https://rusefi.com/build_server/rusefi_bundle_proteus_f4.zip)
 
+Legacy Proteus 0.6 boards with the STM32F767 can behave strangely over SWD programming - see [Proteus F767 Programming Instructions](Proteus-F767-programming-instructions) for the DFU / STM32CubeProgrammer procedure that does work.
+
 ## Wiring & Pinout
 
 [List of I/O](https://github.com/mck1117/proteus#proteus)


### PR DESCRIPTION
`Proteus-F767-programming-instructions` has real recovery content — the working DFU + STM32CubeProgrammer procedure for Proteus 0.6 boards whose F767 misbehaves over SWD — but nothing in the wiki linked to it. It links *out* to `HOWTO-nDBANK`, and had zero inbound links, so it was unreachable unless you already knew the URL.

This adds it to the firmware-update/recovery cluster that already cross-links `HOWTO-Update-Firmware`, `HOWTO-DFU`, `HOWTO-flash-using-Stm32CubeProgrammer`, `F7-requires-full-erase`, `HARDWARE-VALIDATION-FAILED` and `4chan-F7-initial-programming` — it's a direct analogue of the 4chan F7 page those already carry.

- one new bullet in the existing "Related pages" footer on each of those five pages
- the same footer added to the page itself, pointing back
- one line under Proteus Manual → *Legacy Revisions Software*, which already covers 0.3-0.5 and 0.7 as F4 but said nothing about the 0.6 / F767 case

Append-only: 7 files, +17 lines, no existing text changed, no navigation restructured, no pinout content.