### PR TITLE
docs: surface and complete the .ini lookup logic page

### DIFF
--- a/HOWTO-Update-Firmware.md
+++ b/HOWTO-Update-Firmware.md
@@ -80,7 +80,7 @@ ST-LINK is an advanced mode of firmware update which requires ST-LINK device, ei
 
 Once you have updated your firmware, you also need to update your TunerStudio definition so it is able to communicate properly. A happy installation of TunerStudio will download the current .ini file automatically!
 
-If you chose to do it manually, you can find the .ini file in the USB storage device that rusEFI board presents to your computer, or in the [rusEFI bundle](Download).
+If you chose to do it manually, you can find the .ini file in the USB storage device that rusEFI board presents to your computer, or in the [rusEFI bundle](Download). You can also look it up online from the firmware signature - see [.ini Lookup Logic](INI-lookup-logic).
 
 ## Related pages
 

--- a/HOWTO-create-tunerstudio-project.md
+++ b/HOWTO-create-tunerstudio-project.md
@@ -36,6 +36,8 @@ If the definition for your unit wasn't detected automatically, select the file f
 
 Your rusEFI board should also present itself as a USB storage device to your computer, containing the .ini file you need. This is the most foolproof method of making sure you have the correct .ini file.
 
+If you know your firmware signature but do not have the matching file to hand, every official .ini is published online and the URL can be derived from the signature - see [.ini Lookup Logic](INI-lookup-logic).
+
 ![Browse for Definition](Images/TS/TunerStudio_other_browse.png)
 
 After clicking Next, selecting your preferred lambda display mode, and clicking Next again, you'll see this:

--- a/INI-lookup-logic.md
+++ b/INI-lookup-logic.md
@@ -6,3 +6,43 @@ Dots should be replaced with slash and the `.ini` suffix should be added.
 
 For instance, the .ini file for `rusEFI master.2024.02.02.alphax-4chan.1293678056`
 would be available at https://rusefi.com/online/ini/rusefi/master/2024/02/02/alphax-4chan/1293678056.ini
+
+Note that the space in the signature is also a separator - it becomes a slash - and the
+leading name is lower case in the URL, so `rusEFI master.` becomes `rusefi/master/`.
+
+## What the parts of a signature mean
+
+A signature is assembled by `firmware/gen_signature.sh` at build time as:
+
+```
+<white label> <branch>.<YYYY.MM.DD>.<short board name>.<signature hash>
+```
+
+| Part | Where it comes from |
+| --- | --- |
+| White label | `rusEFI` unless the board sets `signature_white_label` |
+| Branch | the git branch the firmware was built from, e.g. `master` |
+| Date | build date, Europe/London |
+| Short board name | the board's `SHORT_BOARD_NAME`, e.g. `uaefi`, `alphax-4chan`, `proteus_f4` |
+| Signature hash | generated from the configuration layout, so it changes whenever the config changes |
+
+Because the hash tracks the configuration layout, a signature identifies one exact
+build - which is why a definition file from a different build will not talk to your ECU.
+
+## Where to find your signature
+
+TunerStudio shows the signature it expects in the project properties, and the firmware
+reports its own signature when probed. If the two do not match, look the correct file up
+with the rule above rather than guessing at a nearby date.
+
+## Related pages
+
+- [How to Create a TunerStudio Project](HOWTO-create-tunerstudio-project) - creating the project, auto-detect and manual definition selection.
+- [How to Update Firmware](HOWTO-Update-Firmware) - updating firmware, and updating the TunerStudio definition afterwards.
+- [rusEFI Bundle](rusEFI-bundle) - what is in the bundle, including `rusefi.ini`.
+- [Tunerstudio Connectivity](Tunerstudio-Connectivity) - connection settings and troubleshooting.
+
+## Technical Sources
+
+- `firmware/gen_signature.sh` - builds the signature string.
+- `firmware/controllers/generated/rusefi_generated_<board>.h` - the resulting `TS_SIGNATURE` define for each board.

--- a/rusEFI-bundle.md
+++ b/rusEFI-bundle.md
@@ -4,7 +4,7 @@ The `rusefi.bin` file is compiled rusEFI firmware. Sometimes you would have a `r
 
 `rusefi.dfu` is also compiled rusEFI firmware, which is used for the DFU mode of flashing.
 
-`rusefi.ini` is the TunerStudio definition file, which you would use if you use TunerStudio software to tune your rusEFI ECU.
+`rusefi.ini` is the TunerStudio definition file, which you would use if you use TunerStudio software to tune your rusEFI ECU. See [.ini Lookup Logic](INI-lookup-logic) if you need to find the definition file for a specific firmware signature.
 
 [TunerStudio Download](http://www.tunerstudio.com/index.php/downloads)
 


### PR DESCRIPTION
`INI-lookup-logic` explains how to derive the URL of any official `.ini` from a firmware signature — exactly what you need when TunerStudio's auto-detect fails or reports a signature mismatch. Nothing linked to it, so it was unreachable.

**Surfaced** from the three places where someone actually hits that problem:
- `HOWTO-create-tunerstudio-project` → *Manual Definition Selection*
- `HOWTO-Update-Firmware` → *Update TunerStudio Definition*
- `rusEFI-bundle` → the `rusefi.ini` entry

**Completed the rule**, which was incomplete: the space in the signature is a separator too, and the leading name is lower case, so `rusEFI master.` becomes `rusefi/master/`. Following the rule exactly as written gave the wrong URL. Verified live — the current uaEFI signature `rusEFI master.2026.08.10.uaefi.328449289` resolves to https://rusefi.com/online/ini/rusefi/master/2026/08/10/uaefi/328449289.ini

**Added a breakdown of the signature format**, taken from `firmware/gen_signature.sh`, so the page explains why a definition file from a different build will not connect. No invented values; the existing text and the existing example are untouched.