### PR TITLE
docs: surface the rusEFI History page

### DIFF
--- a/Case-Studies.md
+++ b/Case-Studies.md
@@ -1,6 +1,6 @@
 # Case Studies
 
-See also [List of Engines Running rusEFI](List-of-Engines-Running-rusEFI) for the running log of builds going back to 2013.
+See also [List of Engines Running rusEFI](List-of-Engines-Running-rusEFI) for the running log of builds going back to 2013, and [rusEFI History](rusEFI-history) for how the project itself got started.
 
 ![GTO race car](Images/gto.jpeg)
 

--- a/Home.md
+++ b/Home.md
@@ -82,6 +82,8 @@ Thinking of doing an engine control project? You have stopped by the correct pla
 
 [Engines running rusEFI](Case-Studies)
 
+[rusEFI History](rusEFI-history) - how the project got here, from a 2012 Ford Aspire test mule onwards
+
 [![Miata rusEFI Racecar!](Images/miata_rusefi_racecar.png)](https://www.youtube.com/embed/3xz66oR95F8?start=8 "Miata rusEFI Racecar!")
 
 [![BMW V12 with dual ETB!](Images/BMW_V12_dual_ETB.png)](https://www.youtube.com/embed/TGf8IMwRuIY "BMW V12 with dual ETB!")  

--- a/rusEFI-history.md
+++ b/rusEFI-history.md
@@ -20,7 +20,7 @@ Honda Accord came with head gasket pre-blown! https://honda-tech.com/forums/engi
 
 That's when Nick has joined the party.
 
-https://github.com/rusefi/rusefi_documentation/wiki/List_of_engines_running_rusEFI
+[List of Engines Running rusEFI](List-of-Engines-Running-rusEFI)
 
 ## 2013
 
@@ -39,3 +39,10 @@ rusEFI has started out of the blue by Andrey.
 ## 2010
 
 Keith, Hoang and Josh has pulled me into 24 hours of Lemons. That's how I got into cars :) https://www.youtube.com/watch?v=nfwEQIIFBlU
+
+## Related pages
+
+- [Case Studies](Case-Studies) - notable builds running rusEFI.
+- [List of Engines Running rusEFI](List-of-Engines-Running-rusEFI) - the running log of builds going back to 2013.
+- [rusEFI Hardware Overview](Hardware) - the boards in production today.
+- [Support & Community](Support) - forum, Discord and where the people in this page's story hang out.


### PR DESCRIPTION
`rusEFI-history` covers the project from the 2010 Lemons race and the 2012 Ford Aspire test mule through Frankenstein, Proteus and the Greek mythology board naming — but nothing linked to it, so the wiki had no route to the project's own story.

- Linked from **Home** under *rusEFI in action*, next to Case Studies
- Linked from **Case Studies**, where the historical see-also line already lives
- Gave the page a Related pages footer back to that cluster

Also replaced the raw `github.com/rusefi/rusefi_documentation/wiki/List_of_engines_running_rusEFI` URL in the body with an internal link to the actual page, `List-of-Engines-Running-rusEFI` — the underscored external form doesn't match the page name, and an in-repo link works under both renderers.

No historical claims added or changed. I checked both images the page references (`Hardware-files/Deucalion/...` and `rusEFI-History-files/...`) and both are present in the repo, so nothing to fix there.