### PR TITLE
docs: say what Discord is and is not good for

### DIFF
--- a/Discord.md
+++ b/Discord.md
@@ -7,3 +7,40 @@
 Discord is a group messenger that can be accessed through your browser or as an application. Use [this invite link](https://discord.gg/rCGAUaZJKF) to enter our chat.
 
 Part of our community [Support](Support) model
+
+## What Discord is good for
+
+Quick one-off questions, and clarification or discussion once the background to a problem
+is already written down somewhere.
+
+## What the forum is for instead
+
+Discord is not a good place for continued help on a project, because context is very
+quickly lost in the stream. The [rusEFI Forum](https://rusefi.com/forum/) is the primary
+free support channel, and it is where anything worth keeping should go - a forum thread is
+indexed by search engines and stays readable long after the conversation scrolls away.
+
+Discord does have threads, but people rarely use them.
+
+## Before you ask for help here
+
+- Establish the context on the forum or in a
+  [GitHub issue](https://github.com/rusefi/rusefi/issues) first. Please do not offload
+  data preservation onto whoever happens to read the chat.
+- Post your tune and logs to [rusEFI Online](Online) so they can be linked rather than
+  re-explained.
+- Read [How to ask for help](Support#how-to-ask-for-help) on the Support page - it lists
+  what to collect before posting.
+
+## Once your problem is solved
+
+Write up what fixed it, on the forum rather than only in chat. Your experience is likely
+to help the next person with the same symptom.
+
+## Related pages
+
+- [Support & Community](Support) - the full support model, paid and community.
+- [Knowledge sharing and Channels](Knowledge-best-practices-and-Channels) - which of our
+  many channels to use for what, and why.
+- [rusEFI Online](Online) - posting tunes and logs so others can look at them.
+- [HOWTO Search on rusEFI wiki](HOWTO-Search-on-rusEFI-wiki) - worth a look before asking.


### PR DESCRIPTION
The Discord page is linked from **13 pages** — mostly board pages (`uaEFI`, `Proteus-Manual`, `Hardware`, `GM-E38`, `nano`, …), i.e. someone who just got hardware and is looking for help. But the page was 46 words explaining what Discord is *as a product*.

The wiki already states the project's position on this, just not anywhere that reader will see it:

- **Support**: Discord is good for quick one-off questions, "but not for continued help on a project, as context is very quickly lost in the stream", and the forum is the primary free support channel.
- **Knowledge sharing and Channels**: establish context on the forum or GitHub *before* dumping data into chat; Discord has threads but people rarely use them.

This brings that guidance onto the Discord page itself — what it's good for, why the forum is preferred for anything worth keeping, what to do before asking, and writing the answer up afterwards. Plus a Related pages footer.

**No new policy is introduced** — every claim is restated from those two existing pages. Append-only; the original text is unchanged.