### PR TITLE
docs: make the returns, warranty and shipping pages reachable

### DIFF
--- a/Hardware.md
+++ b/Hardware.md
@@ -54,5 +54,11 @@ __A:__ So that log file names could include the current time stamp. That functio
 *__Q:__ I would like to fabricate and sell in my country.*  
 __A:__ See [Royalty](Royalty)
 
+*__Q:__ What is the return and warranty policy?*  
+__A:__ See [Returns and Warranty](returns-and-warranty)
+
+*__Q:__ My order has shipped - how do I track it, and what if it goes missing?*  
+__A:__ See [Shipping](Shipping)
+
 *__Q:__ How do I make my own board?*  
 __A:__ [Hellen One Platform](Hellen-One-Platform) is a way to build an ECU from existing functional blocks like knock detection module and wideband controller module.

--- a/Support.md
+++ b/Support.md
@@ -114,4 +114,4 @@ __A:__ Please post your logs and tunes to [rusEFI Online](Online).
 __A:__ Universal standalone ECUs are not trivial; we do not recommend universal standalones as a way to repair a broken vehicle. While you gain openness and confidence in what you deal with, you would have to make quite an effort to calibrate your ECU to a drivable state.
 
 *__Q:__ What is the process for warranty/returns?*  
-__A:__ Once you have exhausted all public community support options including Discord we usually accept returns with a refund.
+__A:__ Once you have exhausted all public community support options including Discord we usually accept returns with a refund. See [Returns and Warranty](returns-and-warranty) for the written policy, and [Shipping](Shipping) for tracking and lost-parcel claims.


### PR DESCRIPTION
`returns-and-warranty` and `Shipping` both had **zero inbound links** — nothing anywhere in the wiki pointed at either, so the commercial terms were effectively unpublished even though the pages exist. A buyer comparing rusEFI against a commercial ECU cannot find the warranty policy.

Linked from the two places people look:
- two FAQ entries on **Hardware**, which is the page carrying the store links
- the existing warranty/returns Q&A answer on **Support**

### One thing for you to decide

This surfaces a contradiction rather than creating one, and I have deliberately **not** picked between the two:

- `Support.md`: "Once you have exhausted all public community support options including Discord we usually **accept returns with a refund**."
- `returns-and-warranty.md`: "**We do not accept returns.**" — followed by limited free returns for obvious manufacturing issues.

The change only puts the two next to each other so the discrepancy is visible. Which is authoritative is a policy question, not a documentation one — happy to follow up with whatever wording you want, or to drop the Support link if you would rather reconcile the pages first.

+7/−1; the only modified line is the Support answer, which is appended to, not reworded.