### PR TITLE
docs: correct stale Lua hook entries against current firmware

### DIFF
--- a/Lua-Scripting.md
+++ b/Lua-Scripting.md
@@ -153,15 +153,11 @@ Percent to add to idle (incl. open loop).
 
 #### `setFuelAdd(amount)`
 
-*Currently not functional*
-
-Amount of fuel mass to add to injection, scaled by fuel multiplier ([`setFuelMult()`](#setfuelmultcoeff)); initially 0.
+Fuel mass in grams added to each injection. Applied after [`setFuelMult()`](#setfuelmultcoeff) has scaled the base mass, so it is not itself scaled by that multiplier; initially 0.
 
 #### `setFuelMult(coeff)`
 
-*Currently not functional*
-
-Amount to scale added fuel mass by; initially 1.0;
+Scales the base injected fuel mass; initially 1.0.
 
 #### `setBoostTargetAdd(amount)`
 
@@ -313,16 +309,16 @@ Output:
 
 #### `setTickRate(hz)`
 
-Sets the rate at which rusEFI calls your `onTick` and `onCanRx` functions, in hz. On reset default is 10hz.
+Sets the rate at which rusEFI calls your `onTick` and `onCanRx` functions, in hz. On reset default is 200hz.
 
 - Parameters
-  - `hz`: Desired tick rate, in hz. Values passed will be clamped to a minimum of 1hz, and maximum of 200hz.
+  - `hz`: Desired tick rate, in hz. Values passed will be clamped to a minimum of 1hz, and maximum of 2000hz. Above 150hz the firmware logs a recommendation to enable `luaCanRxWorkaround` - see [luaCanRxWorkaround](luaCanRxWorkaround).
 - Returns
   - none
 
 #### `mcu_standby()`
 
-Stops MCU.
+Puts MCU into standby low current consumption mode.
 
 #### `interpolate(x1, y1, x2, y2, x)`
 
@@ -352,22 +348,8 @@ Finds curve index by specific curve name
 Looks up a value from the specified Script Curve.
 
 - Parameters
-  - `tableIdx`: Index of the script to use, starting from 1.
+  - `curveIdx`: Index of the curve to use, starting from 1.
   - `x`: Axis value to look up in the table
-
-#### `setDebug(index, value)`
-
-Sets a debug channel to the specified value. Note: this only works when the ECU debug mode is set to `Lua`.
-
-- Parameters
-  - `index`: the index of the debug channel to set, 1 thru 7 inclusive.
-  - `value`: the value to set the channel to
-- Returns
-  - none
-
-#### `mcu_standby`
-
-Puts MCU into standby low current consumption mode.
 
 ### Input
 
@@ -403,7 +385,7 @@ Reads the raw value from the specified sensor. For most sensors, this means the 
 More or less like getSensorRaw but always voltage of aux analog input.
 
 - Parameters
-  - `index`: Index of aux analog sensor to read. From 0 to 3
+  - `index`: Index of aux analog sensor to read. From 0 to 7
 - Returns
   - Voltage of sensor reading, or nil if sensor isn't configured.
 
@@ -418,12 +400,12 @@ Checks whether a particular sensor is configured (whether it is currently valid 
 
 #### `getDigital(index)`
 
-Reads a digital input from the specified channel.
+Reads one of the driver switches tracked by the firmware, which is not the same as reading a pin. Where a physical pin is configured for that switch the pin is used; where one is not, the state is whatever Lua or the rest of the firmware last set (see [`setClutchUpState()`](#setclutchupstatevalue)). To read a pin directly see [`getAuxDigital()`](#getauxdigitalindex).
 
 - Parameters
-  - `index`: The index of the digital channel to read. See table below for values.
+  - `index`: The index of the switch to read. See table below for values.
 - Returns
-  - A boolean value representing the state of the input pin. `true` = high voltage (above ~2 volts), `false` = low voltage (below ~3 volts)
+  - A boolean value representing the state of the switch, or `nil` if `index` is not one of the values below.
 
 Valid `index` parameter values:
 


### PR DESCRIPTION
Nine entries on this page no longer match the firmware. Each row is independently checkable against master (`338c50f`, 2026-08-26).

| Entry | Page said | Firmware does | Evidence |
|---|---|---|---|
| `setDebug` | documents the hook | the hook was deleted | rusefi/rusefi `4d3f9f33` "only:dead", 2026-03-15 — nothing re-registers it |
| `setFuelAdd` / `setFuelMult` | "*Currently not functional*" | both work, and have since 2022 | `engine2.cpp`: `getInjectionMass(rpm) * lua.fuelMult + lua.fuelAdd` |
| `setFuelAdd` | "scaled by fuel multiplier" | added **after** the multiplier, so not scaled by it | same line |
| `setTickRate` default | 10hz | 200hz | `f221a7af39` "default Lua tick rate changed from 10Hz to 200Hz", 2025-06-02 |
| `setTickRate` maximum | 200hz | 2000hz | `4aba2f32f2`, 2025-07-05 — `lua.cpp` now does `clampF(1, userFreq, 2000)` |
| `getAuxAnalog` | index 0 to 3 | 0 to 7 | `SensorType::AuxAnalog1..8`; `LUA_ANALOG_INPUT_COUNT 8` lives in `rusefi_config_shared.txt`, so it is 8 on every board |
| `getDigital` | reads pin voltage, ~2V / ~3V thresholds | returns the resolved switch state, and `nil` above index 3 | `lua_getDigital` reads `engineState.clutchDownState` etc; `getClutchDownState()` uses the pin only where one is configured, else the value Lua set |
| `curve()` | parameter called `tableIdx` | the signature above it says `curveIdx` | — |
| `mcu_standby` | two entries, two different descriptions | one hook | — |

Both `setTickRate` numbers were correct when they were written — the default and the clamp were raised later and the page did not follow.

**One judgement call.** I added the `luaCanRxWorkaround` note beside the new 2000hz ceiling, because `lua.cpp` warns above 150hz and documenting 2000 bare would point people at rates the firmware itself qualifies. Happy to drop that clause if you would rather keep the diff purely numeric.

I left `getAuxDigital`'s voltage wording alone — that one really does read a pin, and I have no way to verify the actual thresholds per board.

**Verified locally:** `markdownlint` with the option set from `wiki-tools/lint.sh`, and `wiki-tools/brokenlinks.sh` — both pass. Nothing anywhere else in the wiki links to the removed `setDebug` or duplicate `mcu_standby` anchors.

**Not verified:** no ARM build, no hardware, no TunerStudio session. These are documentation-only changes read out of current source.

---

Separately, while checking the entries above I noticed some availability and edge-case gaps in the same functions: `mcu_standby` is only compiled on 3 boards (`LUA_STM32_STANDBY`) and raises `criticalError` if called in the first 3 seconds after boot — the CAN example further down this page can hit that; `curve()` silently returns curve 1 for an out-of-range index; `getAuxAnalog` has no bounds check, so index 8+ returns a `LuaGauge` reading. I kept all of that out to keep this PR purely corrective. Worth a follow-up, or not worth the page space?
