### PR TITLE
docs: note the Lua hooks that fail silently

### DIFF
--- a/Lua-Scripting.md
+++ b/Lua-Scripting.md
@@ -320,6 +320,11 @@ Sets the rate at which rusEFI calls your `onTick` and `onCanRx` functions, in hz
 
 Puts MCU into standby low current consumption mode.
 
+Only built on boards that define `LUA_STM32_STANDBY` - it depends on the board leaving PA0 free. On any
+other board the function does not exist, so calling it stops the script with "attempt to call a nil value".
+
+Calling it within the first three seconds after boot raises a critical error instead of entering standby.
+
 #### `interpolate(x1, y1, x2, y2, x)`
 
 Interpolates `x` placing it on the line defined by (x1, y1) and (x2, y2)
@@ -348,7 +353,7 @@ Finds curve index by specific curve name
 Looks up a value from the specified Script Curve.
 
 - Parameters
-  - `curveIdx`: Index of the curve to use, starting from 1.
+  - `curveIdx`: Index of the curve to use, 1 through 6. An out-of-range index silently returns Script Curve #1 - it is not an error and does not return nil.
   - `x`: Axis value to look up in the table
 
 ### Input
@@ -385,7 +390,7 @@ Reads the raw value from the specified sensor. For most sensors, this means the 
 More or less like getSensorRaw but always voltage of aux analog input.
 
 - Parameters
-  - `index`: Index of aux analog sensor to read. From 0 to 7
+  - `index`: Index of aux analog sensor to read. From 0 to 7. The index is not range-checked - 8 and above read the Lua gauges instead, which is not an error and does not return nil.
 - Returns
   - Voltage of sensor reading, or nil if sensor isn't configured.
 


### PR DESCRIPTION
Follow-up to #761, which corrected entries that were factually wrong. These three are not wrong, they are silent: a script author gets no error, just the wrong behaviour.

| Entry | What happens | Source |
|---|---|---|
| `mcu_standby()` | Registered inside `#if defined(LUA_STM32_STANDBY)`, which only three board directories define: alphax-4K-GDI, alphax-8chan and alphax-8chan-revA (the alphax-8chan directory also builds alphax-8chan_f7, so four board images). Everywhere else the symbol is absent and the call ends the script. It also raises `criticalError` if invoked under `STARTUP_STANDBY_PROHIBITED_PERIOD_SEC` (3) seconds after boot. | `lua_hooks_util.cpp` |
| `curve(curveIdx, x)` | `getCurveValue` is a switch whose `default:` arm is scriptCurve1, with explicit cases only for 1..5. `curve(0, x)` and `curve(7, x)` therefore return Script Curve #1 — not nil, not an error. `SCRIPT_CURVE_COUNT` is 6, and the sibling `table3d` entry already states its range. | `script_impl.cpp` |
| `getAuxAnalog(index)` | No bounds check — the index is just an offset from `SensorType::AuxAnalog1`. `LuaGauge1..8` sit immediately after `AuxAnalog8`, so index 8 and above return a Lua gauge reading as though it were an aux analog voltage. | `lua_hooks.cpp`, `sensor_type.h` |

The `getAuxAnalog` one is the easiest to walk into, because the Returns line promises nil for a sensor that "isn't configured" — which reads like it covers an out-of-range index too.

**One thing I did not touch.** The CAN receive example further down the page calls `mcu_standby()` on frame `0x570` with no guard. On a car whose BCM sends that soon after key-on it lands inside the three second window and critical-errors. It is your example, so I left it alone — say the word and I will add a guard or a comment to it.

**Verified locally:** `markdownlint` with the option set from `wiki-tools/lint.sh`, and `wiki-tools/brokenlinks.sh` — both pass.

**Not verified:** no ARM build, no hardware, no TunerStudio session. Documentation-only changes read out of current source.
