### PR TITLE
docs: explain how to actually get a Lua script onto the ECU

### DIFF
--- a/Lua-Scripting.md
+++ b/Lua-Scripting.md
@@ -28,6 +28,49 @@ Some example uses are provided in [Examples](#examples).
 - The Lua interpreter will trigger an error if there is a mistake in the program; check the rusEFI console to see errors and script output.
 - Unless otherwise mentioned, all `index` parameters start with the first element at index 0.
 
+## Installing a Script
+
+Lua scripts are written and loaded from the **rusEFI console**, not from TunerStudio - TunerStudio's own
+Lua pages say so directly: *"Use rusEFI console for Lua script editing"*. If you do not have the console
+yet, see [Console](Console).
+
+1. **Connect the console to the ECU and open the `Lua Scripting` tab.**
+   It has the script editor on the left, a live message pane on the right, and a row of buttons along the
+   top.
+
+2. **Type or paste your script into the editor.**
+   How much room you have depends on the board - 8000 bytes on most, but a good deal more on some, up to
+   48000 on Proteus F7 and uaEFI Pro. Rather than guess, read the `used/limit` counter under the editor:
+   it reports the real limit for whatever board you are connected to. While connected the editor also
+   refuses input past that limit and beeps, instead of truncating silently. Scripts are sent as plain
+   ASCII, so avoid accented characters and other non-ASCII symbols even inside comments and strings.
+
+3. **Press `Write to ECU`.**
+   This sends the script to the ECU *and* restarts the Lua interpreter, so your script begins running
+   straight away. Nothing has been written to flash yet.
+
+4. **Watch the message pane.**
+   `LUA script loaded successfully!` means it is running. Anything your script prints appears there with
+   a `LUA:` prefix. A printed message containing `BEEP` also makes the console beep, which is useful when
+   you are under the car and cannot see the screen.
+
+5. **Press `Burn to ECU` when you are happy with it.**
+   This stores the configuration, including your script, in the ECU so that it runs again at the next
+   boot. Power-cycle the ECU and confirm the script still runs before you rely on it.
+
+Burning does **not** reload the interpreter on its own. The restart that happens during `Write to ECU` is
+what puts a new script into effect.
+
+### When a script does not run
+
+A script that fails to load prints `LUA ERROR loading script:` followed by the Lua error message, and the
+interpreter then **stops and waits** - it does not keep retrying. Fix the script and press `Write to ECU`
+again, or use `More... -> Reset Lua`.
+
+Every restart also clears whatever the previous run had set: the tick rate returns to 200hz and the
+adjustments such as [`setTimingAdd()`](#settimingaddangle) and [`setFuelMult()`](#setfuelmultcoeff) go
+back to their defaults. Set those at the top level of your script rather than once inside a condition.
+
 ## Writing Your Script
 
 The entire Lua script is read at startup, then a script function called `onTick` is called periodically by rusEFI.
@@ -59,6 +102,41 @@ end
 
 To ease editing a Lua script, an editor that supports Language Server Protocol (LSP) is highly recommended.
 For an option see [LuaLS/lua-language-server](https://github.com/LuaLS/lua-language-server#install)
+
+#### Keeping the script in your own files
+
+The console editor understands two comment directives that let you keep the real script on disk and pull
+it back in. Point the console at the folder holding those files with `More... -> Select Working Folder`.
+
+| Directive | What it does |
+| --- | --- |
+| `-- scriptname NAME` | Names the file this script came from. `More...` then offers `Reload NAME`, which re-reads it from the working folder. |
+| `-- include NAME` ... `-- endinclude` | When the script is reloaded, everything between the two markers is replaced with the current contents of `NAME`. Put shared helpers in their own file and include them. |
+
+``` lua
+-- scriptname my-dash.lua
+
+-- include can-helpers.lua
+-- endinclude
+
+function onTick()
+  sendDashFrame()
+end
+```
+
+Two things to know before using `Reload`:
+
+- **It is not a read-only operation.** `Reload` assembles the file plus its includes, puts the result in
+  the editor, and then does exactly what `Write to ECU` does - it sends the script and restarts the
+  interpreter. Do not click it on a running engine expecting only to look at the file.
+- Because the assembled text lands *in the editor*, the size limit applies to what you end up seeing
+  there, includes and all. If the result does not fit, the editor is replaced by a message saying so and
+  nothing is sent.
+
+Every `-- include` needs a matching `-- endinclude`. Without one the menu item fails and simply appears to
+do nothing.
+
+`More... -> Format Script` re-indents whatever is currently in the editor.
 
 ## Hooks/Function Reference
 
@@ -605,9 +683,17 @@ end
 
 ## Misc console commands
 
-`luamemory`
+Type these into the command box at the top of the `Lua Scripting` tab, or anywhere else the console takes
+commands.
 
-`luareset`
+| Command | Effect |
+| --- | --- |
+| `lua <code>` | Runs a fragment of Lua inside the *running* interpreter, so it can see your script's variables. It executes on the next tick. The console splits the command line on spaces, so the code has to contain none: `lua print(rpm)` works, `lua x = 5` does not. |
+| `luareset` | Restarts the interpreter and runs your script again from the top. |
+| `luamemory` | Prints the worst-case script duration since you last asked, CAN RX totals and drops, the last cycle time, and Lua heap usage. |
+| `lua_button <index>` | Simulates a press of TunerStudio Lua button 1 to 10, so button handlers can be developed without TunerStudio open. |
+| `luabench2 <index> <onMs> <offMs> <count>` | Pulses one Lua output pin. `index` counts from 1. |
+| `set_lua_setting <index> <value>` | Sets one of the Lua Script Settings without going through TunerStudio. Here `index` counts from **0**, so 0 to 7. It is not bounds-checked, and a value outside that range writes over unrelated configuration - so do not use one. |
 
 ## Examples
 


### PR DESCRIPTION
The page has never said how to actually install a script. It opens with *"Launch rusEFI Console and click on the Lua tab"* and then goes straight into the API, so a first-time user does not know what the buttons do, what happens when the script has a syntax error, or why it disappeared after a power cycle. Nothing else in the wiki covers it either — no page anywhere mentions Write to ECU or Burn to ECU.

Three changes, all read out of the console and firmware source.

### 1. New "Installing a Script" section

Five numbered steps, plus the two things that catch people out:

- **Write to ECU is what reloads the interpreter, not Burn.** `writeScriptToEcu()` calls `writeInBlocks(...)` and then `resetLua()`; the burn button only calls `bp.burn()`. The comment in that method says as much.
- **A failed script stops and waits.** `LuaThread::ThreadTask` spins on `chThdSleepMilliseconds(100)` until `needsReset` rather than retrying, so the fix is to Write again or Reset Lua. And `engine->resetLua()` runs between attempts with the tick period back to `MS2US(5)`, so every adjustment and the tick rate reset on each restart.

I deliberately did **not** print a single size number. `LUA_SCRIPT_SIZE` defaults to 8000 but boards override it in `prepend.txt` — 10000 on microRusEFI and Proteus F4, 13500 on Proteus H7, 26000 on alphaX 4K GDI, 40000 on alphaX 8chan F7, 48000 on Proteus F7 and uaEFI Pro. The console reads the real figure from the active `.ini` and shows it as a `used/limit` counter under the editor, so the page points there instead of at a number that is wrong for half the boards.

### 2. "Keeping the script in your own files"

The `-- scriptname` and `-- include` / `-- endinclude` directives that `LuaIncludeSyntax` implements, plus Select Working Folder and Format Script. Not documented anywhere until now.

Two warnings that seemed worth spelling out:

- **`Reload` is not a read-only look at the file.** `reloadFromDisc()` expands the includes into the editor with `setText(newLua)` and then calls `writeScriptToEcu()` — so it pushes the script and restarts the interpreter. Clicking it on a running engine does more than you would expect.
- An unmatched `-- include` throws `IllegalStateException` out of `reloadScript`, and `reloadFromDisc` catches only `IOException`, so the menu item just appears to do nothing.

### 3. Misc console commands

It was a bare list of two commands with no explanation. Now a table of six.

Worth noting `lua <code>` only accepts space-free code: `handleConsoleLineInternal` tokenises on whitespace and rejects a mismatched argument count, so `lua print(rpm)` works while `lua x = 5` returns "Incorrect argument count". That looks like it should work, so the row says it does not.

Index bases differ between the two bench commands and are stated per source: `luabench2` validates `1..LUA_PWM_COUNT`, while `set_lua_setting` indexes `scriptSetting[8]` from 0 with no bound check — an out-of-range index there writes over neighbouring configuration, so that row is worded as a warning rather than a note.

Linked to the existing [Console](Console) page rather than repeating how to obtain the console.

**Verified locally:** `markdownlint` with the option set from `wiki-tools/lint.sh`, and `wiki-tools/brokenlinks.sh` — both pass.

**Not verified:** no ARM build, no hardware, no TunerStudio session. Documentation-only changes read out of current source.
